### PR TITLE
Setting UID/GID in the migrid container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,6 +127,10 @@ mig/
 docker-compose.yml
 Dockerfile
 
+# Also include docker-compose.override.yml, to be able to follow
+# upstream compose, but have local overrides untracked by git
+docker-compose.override.yml
+
 # Generated helpers to skip
 migrid-httpd-init.sh
 MiG-certificates

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -10,6 +10,8 @@
 #            explicitly listed in docker-compose.yml *args* list, too.
 #            Furthermore they must be declared after FROM in each stage used.
 
+ARG UID=1000
+ARG GID=1000
 ARG BUILD_TYPE=basic
 ARG BUILD_TARGET=development
 ARG DOMAIN=migrid.test
@@ -200,6 +202,8 @@ ARG ENABLE_SELF_SIGNED_CERTS
 ARG UPGRADE_MOD_AUTH_OPENIDC
 ARG WITH_PY3
 ARG PREFER_PYTHON3
+ARG UID
+ARG GID
 
 WORKDIR /tmp
 
@@ -382,8 +386,8 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 # Setup user
 ENV USER=mig
 ENV GROUP=mig
-ENV UID=1000
-ENV GID=1000
+#ENV UID=1000
+#ENV GID=1000
 
 RUN groupadd -g $GID $USER
 RUN useradd -u $UID -g $GID -ms /bin/bash $USER

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -386,8 +386,6 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 # Setup user
 ENV USER=mig
 ENV GROUP=mig
-#ENV UID=1000
-#ENV GID=1000
 
 RUN groupadd -g $GID $USER
 RUN useradd -u $UID -g $GID -ms /bin/bash $USER

--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -10,6 +10,8 @@
 #            explicitly listed in docker-compose.yml *args* list, too.
 #            Furthermore they must be declared after FROM in each stage used.
 
+ARG UID=1000
+ARG GID=1000
 ARG BUILD_TYPE=basic
 ARG BUILD_TARGET=development
 ARG DOMAIN=migrid.test
@@ -200,6 +202,8 @@ ARG ENABLE_SELF_SIGNED_CERTS
 ARG BUILD_MOD_AUTH_OPENID
 ARG WITH_PY3
 ARG PREFER_PYTHON3
+ARG UID
+ARG GID
 
 WORKDIR /tmp
 
@@ -423,8 +427,6 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 # Setup user
 ENV USER=mig
 ENV GROUP=mig
-ENV UID=1000
-ENV GID=1000
 
 RUN groupadd -g $GID $USER
 RUN useradd -u $UID -g $GID -ms /bin/bash $USER

--- a/advanced.env
+++ b/advanced.env
@@ -10,6 +10,10 @@
 #BUILD_TYPE=advanced
 BUILD_TYPE=basic
 
+# Set UID and GID for the user in the container
+UID=1000
+GID=1000
+
 # Which target system is the image being generated for
 # {development, production}
 BUILD_TARGET=development

--- a/docker-compose_bench.erda.dk_full.yml
+++ b/docker-compose_bench.erda.dk_full.yml
@@ -33,6 +33,8 @@ services:
       dockerfile: Dockerfile
       # IMPORTANT: pass all ARGs used in Dockerfile here to allow optional override from .env file
       args:
+        UID: ${UID}
+        GID: ${GID}
         BUILD_TYPE: ${BUILD_TYPE}
         BUILD_TARGET: ${BUILD_TARGET}
         DOMAIN: ${DOMAIN}
@@ -196,6 +198,8 @@ services:
       dockerfile: Dockerfile
       # IMPORTANT: pass all ARGs used in Dockerfile here to allow optional override from .env file
       args:
+        UID: ${UID}
+        GID: ${GID}
         BUILD_TYPE: ${BUILD_TYPE}
         BUILD_TARGET: ${BUILD_TARGET}
         DOMAIN: ${DOMAIN}
@@ -365,6 +369,8 @@ services:
       dockerfile: Dockerfile
       # IMPORTANT: pass all ARGs used in Dockerfile here to allow optional override from .env file
       args:
+        UID: ${UID}
+        GID: ${GID}
         BUILD_TYPE: ${BUILD_TYPE}
         BUILD_TARGET: ${BUILD_TARGET}
         DOMAIN: ${DOMAIN}
@@ -523,6 +529,8 @@ services:
       dockerfile: Dockerfile
       # IMPORTANT: pass all ARGs used in Dockerfile here to allow optional override from .env file
       args:
+        UID: ${UID}
+        GID: ${GID}
         BUILD_TYPE: ${BUILD_TYPE}
         BUILD_TARGET: ${BUILD_TARGET}
         DOMAIN: ${DOMAIN}
@@ -682,6 +690,8 @@ services:
       dockerfile: Dockerfile
       # IMPORTANT: pass all ARGs used in Dockerfile here to allow optional override from .env file
       args:
+        UID: ${UID}
+        GID: ${GID}
         BUILD_TYPE: ${BUILD_TYPE}
         BUILD_TARGET: ${BUILD_TARGET}
         DOMAIN: ${DOMAIN}
@@ -841,6 +851,8 @@ services:
       dockerfile: Dockerfile
       # IMPORTANT: pass all ARGs used in Dockerfile here to allow optional override from .env file
       args:
+        UID: ${UID}
+        GID: ${GID}
         BUILD_TYPE: ${BUILD_TYPE}
         BUILD_TARGET: ${BUILD_TARGET}
         DOMAIN: ${DOMAIN}

--- a/docker-compose_dag.test.yml
+++ b/docker-compose_dag.test.yml
@@ -31,6 +31,8 @@ services:
       dockerfile: Dockerfile
       # IMPORTANT: pass all ARGs used in Dockerfile here to allow optional override from .env file
       args:
+        UID: ${UID}
+        GID: ${GID}
         BUILD_TYPE: ${BUILD_TYPE}
         BUILD_TARGET: ${BUILD_TARGET}
         DOMAIN: ${DOMAIN}
@@ -191,6 +193,8 @@ services:
       dockerfile: Dockerfile
       # IMPORTANT: pass all ARGs used in Dockerfile here to allow optional override from .env file
       args:
+        UID: ${UID}
+        GID: ${GID}
         BUILD_TYPE: ${BUILD_TYPE}
         BUILD_TARGET: ${BUILD_TARGET}
         DOMAIN: ${DOMAIN}
@@ -359,6 +363,8 @@ services:
       dockerfile: Dockerfile
       # IMPORTANT: pass all ARGs used in Dockerfile here to allow optional override from .env file
       args:
+        UID: ${UID}
+        GID: ${GID}
         BUILD_TYPE: ${BUILD_TYPE}
         BUILD_TARGET: ${BUILD_TARGET}
         DOMAIN: ${DOMAIN}
@@ -515,6 +521,8 @@ services:
       dockerfile: Dockerfile
       # IMPORTANT: pass all ARGs used in Dockerfile here to allow optional override from .env file
       args:
+        UID: ${UID}
+        GID: ${GID}
         BUILD_TYPE: ${BUILD_TYPE}
         BUILD_TARGET: ${BUILD_TARGET}
         DOMAIN: ${DOMAIN}
@@ -672,6 +680,8 @@ services:
       dockerfile: Dockerfile
       # IMPORTANT: pass all ARGs used in Dockerfile here to allow optional override from .env file
       args:
+        UID: ${UID}
+        GID: ${GID}
         BUILD_TYPE: ${BUILD_TYPE}
         BUILD_TARGET: ${BUILD_TARGET}
         DOMAIN: ${DOMAIN}
@@ -829,6 +839,8 @@ services:
       dockerfile: Dockerfile
       # IMPORTANT: pass all ARGs used in Dockerfile here to allow optional override from .env file
       args:
+        UID: ${UID}
+        GID: ${GID}
         BUILD_TYPE: ${BUILD_TYPE}
         BUILD_TARGET: ${BUILD_TARGET}
         DOMAIN: ${DOMAIN}

--- a/docker-compose_dev.erda.dk_full.yml
+++ b/docker-compose_dev.erda.dk_full.yml
@@ -33,6 +33,8 @@ services:
       dockerfile: Dockerfile
       # IMPORTANT: pass all ARGs used in Dockerfile here to allow optional override from .env file
       args:
+        UID: ${UID}
+        GID: ${GID}
         BUILD_TYPE: ${BUILD_TYPE}
         BUILD_TARGET: ${BUILD_TARGET}
         DOMAIN: ${DOMAIN}
@@ -196,6 +198,8 @@ services:
       dockerfile: Dockerfile
       # IMPORTANT: pass all ARGs used in Dockerfile here to allow optional override from .env file
       args:
+        UID: ${UID}
+        GID: ${GID}
         BUILD_TYPE: ${BUILD_TYPE}
         BUILD_TARGET: ${BUILD_TARGET}
         DOMAIN: ${DOMAIN}
@@ -365,6 +369,8 @@ services:
       dockerfile: Dockerfile
       # IMPORTANT: pass all ARGs used in Dockerfile here to allow optional override from .env file
       args:
+        UID: ${UID}
+        GID: ${GID}
         BUILD_TYPE: ${BUILD_TYPE}
         BUILD_TARGET: ${BUILD_TARGET}
         DOMAIN: ${DOMAIN}
@@ -523,6 +529,8 @@ services:
       dockerfile: Dockerfile
       # IMPORTANT: pass all ARGs used in Dockerfile here to allow optional override from .env file
       args:
+        UID: ${UID}
+        GID: ${GID}
         BUILD_TYPE: ${BUILD_TYPE}
         BUILD_TARGET: ${BUILD_TARGET}
         DOMAIN: ${DOMAIN}
@@ -682,6 +690,8 @@ services:
       dockerfile: Dockerfile
       # IMPORTANT: pass all ARGs used in Dockerfile here to allow optional override from .env file
       args:
+        UID: ${UID}
+        GID: ${GID}
         BUILD_TYPE: ${BUILD_TYPE}
         BUILD_TARGET: ${BUILD_TARGET}
         DOMAIN: ${DOMAIN}
@@ -841,6 +851,8 @@ services:
       dockerfile: Dockerfile
       # IMPORTANT: pass all ARGs used in Dockerfile here to allow optional override from .env file
       args:
+        UID: ${UID}
+        GID: ${GID}
         BUILD_TYPE: ${BUILD_TYPE}
         BUILD_TARGET: ${BUILD_TARGET}
         DOMAIN: ${DOMAIN}

--- a/docker-compose_dev.erda.dk_wrapped.yml
+++ b/docker-compose_dev.erda.dk_wrapped.yml
@@ -31,6 +31,8 @@ services:
       dockerfile: Dockerfile
       # IMPORTANT: pass all ARGs used in Dockerfile here to allow optional override from .env file
       args:
+        UID: ${UID}
+        GID: ${GID}
         BUILD_TYPE: ${BUILD_TYPE}
         BUILD_TARGET: ${BUILD_TARGET}
         DOMAIN: ${DOMAIN}
@@ -188,6 +190,8 @@ services:
       dockerfile: Dockerfile
       # IMPORTANT: pass all ARGs used in Dockerfile here to allow optional override from .env file
       args:
+        UID: ${UID}
+        GID: ${GID}
         BUILD_TYPE: ${BUILD_TYPE}
         BUILD_TARGET: ${BUILD_TARGET}
         DOMAIN: ${DOMAIN}
@@ -352,6 +356,8 @@ services:
       dockerfile: Dockerfile
       # IMPORTANT: pass all ARGs used in Dockerfile here to allow optional override from .env file
       args:
+        UID: ${UID}
+        GID: ${GID}
         BUILD_TYPE: ${BUILD_TYPE}
         BUILD_TARGET: ${BUILD_TARGET}
         DOMAIN: ${DOMAIN}
@@ -505,6 +511,8 @@ services:
       dockerfile: Dockerfile
       # IMPORTANT: pass all ARGs used in Dockerfile here to allow optional override from .env file
       args:
+        UID: ${UID}
+        GID: ${GID}
         BUILD_TYPE: ${BUILD_TYPE}
         BUILD_TARGET: ${BUILD_TARGET}
         DOMAIN: ${DOMAIN}
@@ -659,6 +667,8 @@ services:
       dockerfile: Dockerfile
       # IMPORTANT: pass all ARGs used in Dockerfile here to allow optional override from .env file
       args:
+        UID: ${UID}
+        GID: ${GID}
         BUILD_TYPE: ${BUILD_TYPE}
         BUILD_TARGET: ${BUILD_TARGET}
         DOMAIN: ${DOMAIN}
@@ -813,6 +823,8 @@ services:
       dockerfile: Dockerfile
       # IMPORTANT: pass all ARGs used in Dockerfile here to allow optional override from .env file
       args:
+        UID: ${UID}
+        GID: ${GID}
         BUILD_TYPE: ${BUILD_TYPE}
         BUILD_TARGET: ${BUILD_TARGET}
         DOMAIN: ${DOMAIN}

--- a/docker-compose_gdp.test.yml
+++ b/docker-compose_gdp.test.yml
@@ -31,6 +31,8 @@ services:
       dockerfile: Dockerfile
       # IMPORTANT: pass all ARGs used in Dockerfile here to allow optional override from .env file
       args:
+        UID: ${UID}
+        GID: ${GID}
         BUILD_TYPE: ${BUILD_TYPE}
         BUILD_TARGET: ${BUILD_TARGET}
         DOMAIN: ${DOMAIN}
@@ -176,6 +178,8 @@ services:
       dockerfile: Dockerfile
       # IMPORTANT: pass all ARGs used in Dockerfile here to allow optional override from .env file
       args:
+        UID: ${UID}
+        GID: ${GID}
         BUILD_TYPE: ${BUILD_TYPE}
         BUILD_TARGET: ${BUILD_TARGET}
         DOMAIN: ${DOMAIN}
@@ -325,6 +329,8 @@ services:
       dockerfile: Dockerfile
       # IMPORTANT: pass all ARGs used in Dockerfile here to allow optional override from .env file
       args:
+        UID: ${UID}
+        GID: ${GID}
         BUILD_TYPE: ${BUILD_TYPE}
         BUILD_TARGET: ${BUILD_TARGET}
         DOMAIN: ${DOMAIN}
@@ -461,6 +467,8 @@ services:
       dockerfile: Dockerfile
       # IMPORTANT: pass all ARGs used in Dockerfile here to allow optional override from .env file
       args:
+        UID: ${UID}
+        GID: ${GID}
         BUILD_TYPE: ${BUILD_TYPE}
         BUILD_TARGET: ${BUILD_TARGET}
         DOMAIN: ${DOMAIN}
@@ -599,6 +607,8 @@ services:
       dockerfile: Dockerfile
       # IMPORTANT: pass all ARGs used in Dockerfile here to allow optional override from .env file
       args:
+        UID: ${UID}
+        GID: ${GID}
         BUILD_TYPE: ${BUILD_TYPE}
         BUILD_TARGET: ${BUILD_TARGET}
         DOMAIN: ${DOMAIN}
@@ -737,6 +747,8 @@ services:
       dockerfile: Dockerfile
       # IMPORTANT: pass all ARGs used in Dockerfile here to allow optional override from .env file
       args:
+        UID: ${UID}
+        GID: ${GID}
         BUILD_TYPE: ${BUILD_TYPE}
         BUILD_TARGET: ${BUILD_TARGET}
         DOMAIN: ${DOMAIN}

--- a/docker-compose_migrid.test.yml
+++ b/docker-compose_migrid.test.yml
@@ -31,6 +31,8 @@ services:
       dockerfile: Dockerfile
       # IMPORTANT: pass all ARGs used in Dockerfile here to allow optional override from .env file
       args:
+        UID: ${UID}
+        GID: ${GID}
         BUILD_TYPE: ${BUILD_TYPE}
         BUILD_TARGET: ${BUILD_TARGET}
         DOMAIN: ${DOMAIN}
@@ -191,6 +193,8 @@ services:
       dockerfile: Dockerfile
       # IMPORTANT: pass all ARGs used in Dockerfile here to allow optional override from .env file
       args:
+        UID: ${UID}
+        GID: ${GID}
         BUILD_TYPE: ${BUILD_TYPE}
         BUILD_TARGET: ${BUILD_TARGET}
         DOMAIN: ${DOMAIN}
@@ -359,6 +363,8 @@ services:
       dockerfile: Dockerfile
       # IMPORTANT: pass all ARGs used in Dockerfile here to allow optional override from .env file
       args:
+        UID: ${UID}
+        GID: ${GID}
         BUILD_TYPE: ${BUILD_TYPE}
         BUILD_TARGET: ${BUILD_TARGET}
         DOMAIN: ${DOMAIN}
@@ -515,6 +521,8 @@ services:
       dockerfile: Dockerfile
       # IMPORTANT: pass all ARGs used in Dockerfile here to allow optional override from .env file
       args:
+        UID: ${UID}
+        GID: ${GID}
         BUILD_TYPE: ${BUILD_TYPE}
         BUILD_TARGET: ${BUILD_TARGET}
         DOMAIN: ${DOMAIN}
@@ -672,6 +680,8 @@ services:
       dockerfile: Dockerfile
       # IMPORTANT: pass all ARGs used in Dockerfile here to allow optional override from .env file
       args:
+        UID: ${UID}
+        GID: ${GID}
         BUILD_TYPE: ${BUILD_TYPE}
         BUILD_TARGET: ${BUILD_TARGET}
         DOMAIN: ${DOMAIN}
@@ -829,6 +839,8 @@ services:
       dockerfile: Dockerfile
       # IMPORTANT: pass all ARGs used in Dockerfile here to allow optional override from .env file
       args:
+        UID: ${UID}
+        GID: ${GID}
         BUILD_TYPE: ${BUILD_TYPE}
         BUILD_TARGET: ${BUILD_TARGET}
         DOMAIN: ${DOMAIN}


### PR DESCRIPTION
The default UID/GID of the mig user, clashes with local user on the machine we have running the containers. This should enable us to set it in the .env file.