### PR TITLE
Pr/docker postfix

### DIFF
--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -63,6 +63,7 @@ ARG MIG_GIT_REV=b6c6a42c3952f8753f60a2f2571b99e3d48f5b11
 ARG ADMIN_EMAIL=mig
 ARG ADMIN_LIST=
 ARG SMTP_SENDER=
+ARG SMTP_SERVER=
 ARG LOG_LEVEL=info
 ARG TITLE="Minimum intrusion Grid"
 ARG SHORT_TITLE=MiG
@@ -761,6 +762,7 @@ ARG OPENID_SHOW_PORT
 ARG ADMIN_EMAIL
 ARG ADMIN_LIST
 ARG SMTP_SENDER
+ARG SMTP_SERVER
 ARG LOG_LEVEL
 ARG TITLE
 ARG SHORT_TITLE
@@ -860,6 +862,7 @@ RUN python2 ./generateconfs.py --source=. \
     --user=$USER --group=$GROUP --log_level=${LOG_LEVEL} \
     --admin_email="${ADMIN_EMAIL}" --admin_list="${ADMIN_LIST}" \
     --smtp_sender="${SMTP_SENDER}" \
+    --smtp_server="${SMTP_SERVER}" \
     --apache_version=2.4 \
     --apache_etc=$WEB_DIR \
     --apache_run=/var/run/httpd \

--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -63,6 +63,7 @@ ARG MIG_GIT_REV=b6c6a42c3952f8753f60a2f2571b99e3d48f5b11
 ARG ADMIN_EMAIL=mig
 ARG ADMIN_LIST=
 ARG SMTP_SENDER=
+ARG SMTP_SERVER=
 ARG LOG_LEVEL=info
 ARG TITLE="Minimum intrusion Grid"
 ARG SHORT_TITLE=MiG
@@ -791,6 +792,7 @@ ARG OPENID_SHOW_PORT
 ARG ADMIN_EMAIL
 ARG ADMIN_LIST
 ARG SMTP_SENDER
+ARG SMTP_SERVER
 ARG LOG_LEVEL
 ARG TITLE
 ARG SHORT_TITLE
@@ -901,6 +903,7 @@ RUN ./generateconfs.py --source=. \
     --user=$USER --group=$GROUP --log_level=${LOG_LEVEL} \
     --admin_email="${ADMIN_EMAIL}" --admin_list="${ADMIN_LIST}" \
     --smtp_sender="${SMTP_SENDER}" \
+    --smtp_server="${SMTP_SERVER}" \
     --apache_version=2.4 \
     --apache_etc=$WEB_DIR \
     --apache_run=/var/run/httpd \

--- a/defaults.env
+++ b/defaults.env
@@ -68,6 +68,7 @@ FTPS_PASSIVE_PORTS=8100-8200
 ADMIN_EMAIL="MiG Info <mig@migrid.test>"
 ADMIN_LIST=
 SMTP_SENDER=
+SMTP_SERVER=mail.migrid.test
 LOG_LEVEL=info
 TITLE="Minimum intrusion Grid"
 SHORT_TITLE=MiG

--- a/defaults.env
+++ b/defaults.env
@@ -153,7 +153,7 @@ MIG_SVN_REV=5682
 # Which git repo and version of migrid should be used
 MIG_GIT_REPO=https://github.com/ucphhpc/migrid-sync.git
 MIG_GIT_BRANCH=edge
-MIG_GIT_REV=908a00d91672f148e06a8529b05ed7215f621b0f
+MIG_GIT_REV=38c41febe4f76ca67e598683c44279948806a650
 
 # Whether to run migrid IO daemons from a single shared container
 # or as one container per service. Env variable is used be docker-compose

--- a/defaults_gdp.test.env
+++ b/defaults_gdp.test.env
@@ -36,6 +36,7 @@ OPENID_DOMAIN=openid.gdp.test
 FTPS_DOMAIN=ftps.gdp.test
 SFTP_DOMAIN=sftp.gdp.test
 WEBDAVS_DOMAIN=webdavs.gdp.test
+MAIL_DOMAIN=mail.migrid.test
 MIG_OID_PROVIDER=https://ext.gdp.test/openid/
 EXT_OID_PROVIDER=unset
 EXT_OIDC_PROVIDER_META_URL=unset

--- a/doc/source/sections/getting-started/introduction.rst
+++ b/doc/source/sections/getting-started/introduction.rst
@@ -20,6 +20,10 @@ Associated Services
 The Associated services, are services that makes it possible to host and run the MiGrid on your local machine.
 These include the dynamic DNS service (devdns), and the Proxy service (nginx-proxy).
 
+- devmail
+    This service provides a simple Postfix based email relay. Make sure to set the ``$SMTP_SERVER`` variable to use this.
+    For development only, as it is an open relay!
+
 - devdns
     This service ensures that every container name is registered as an DNS entry in the devdns service under the `test` domain.
     In addition, it makes it possible for us to register additional aliases for each container, whereby they also can be reached.

--- a/docker-compose_migrid.test.yml
+++ b/docker-compose_migrid.test.yml
@@ -1,6 +1,19 @@
 version: '3.7'
 
 services:
+  devmail:
+    image: mwader/postfix-relay
+    container_name: devmail
+    depends_on:
+      - devdns
+    ports:
+      - "127.0.0.1:25:25"
+    environment:
+      POSTFIX_myhostname: ${SMTP_SERVER}
+    networks:
+      default:
+        aliases:
+          - mail.migrid.test
   devdns:
     image: ruudud/devdns
     container_name: devdns
@@ -78,6 +91,7 @@ services:
         ADMIN_EMAIL: ${ADMIN_EMAIL}
         ADMIN_LIST: ${ADMIN_LIST}
         SMTP_SENDER: ${SMTP_SENDER}
+        SMTP_SERVER: ${SMTP_SERVER}
         LOG_LEVEL: ${LOG_LEVEL}
         TITLE: ${TITLE}
         SHORT_TITLE: ${SHORT_TITLE}
@@ -254,6 +268,7 @@ services:
         ADMIN_EMAIL: ${ADMIN_EMAIL}
         ADMIN_LIST: ${ADMIN_LIST}
         SMTP_SENDER: ${SMTP_SENDER}
+        SMTP_SERVER: ${SMTP_SERVER}
         LOG_LEVEL: ${LOG_LEVEL}
         TITLE: ${TITLE}
         SHORT_TITLE: ${SHORT_TITLE}
@@ -435,6 +450,7 @@ services:
         ADMIN_EMAIL: ${ADMIN_EMAIL}
         ADMIN_LIST: ${ADMIN_LIST}
         SMTP_SENDER: ${SMTP_SENDER}
+        SMTP_SERVER: ${SMTP_SERVER}
         LOG_LEVEL: ${LOG_LEVEL}
         TITLE: ${TITLE}
         SHORT_TITLE: ${SHORT_TITLE}
@@ -602,6 +618,7 @@ services:
         ADMIN_EMAIL: ${ADMIN_EMAIL}
         ADMIN_LIST: ${ADMIN_LIST}
         SMTP_SENDER: ${SMTP_SENDER}
+        SMTP_SERVER: ${SMTP_SERVER}
         LOG_LEVEL: ${LOG_LEVEL}
         TITLE: ${TITLE}
         SHORT_TITLE: ${SHORT_TITLE}
@@ -772,6 +789,7 @@ services:
         ADMIN_EMAIL: ${ADMIN_EMAIL}
         ADMIN_LIST: ${ADMIN_LIST}
         SMTP_SENDER: ${SMTP_SENDER}
+        SMTP_SERVER: ${SMTP_SERVER}
         LOG_LEVEL: ${LOG_LEVEL}
         TITLE: ${TITLE}
         SHORT_TITLE: ${SHORT_TITLE}
@@ -942,6 +960,7 @@ services:
         ADMIN_EMAIL: ${ADMIN_EMAIL}
         ADMIN_LIST: ${ADMIN_LIST}
         SMTP_SENDER: ${SMTP_SENDER}
+        SMTP_SERVER: ${SMTP_SERVER}
         LOG_LEVEL: ${LOG_LEVEL}
         TITLE: ${TITLE}
         SHORT_TITLE: ${SHORT_TITLE}


### PR DESCRIPTION
This PR makes use of the `SMTP_SERVER` variable and adds a simple postfix container to the default example.