### PR TITLE
Feature: added CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: Continuous Integration
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    branches:
+      - master
+    paths-ignore:
+      - '**/README.md'
+      - 'doc/**'
+      - '1.gocd.yml'
+      - '.gitignore'
+
+jobs:
+  default-centos7:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build images
+        run: |
+          make init
+          make dockerbuild
+      - name: Start services
+        run: |
+          docker-compose up -d
+      #- name: Run tests
+      #  run: |
+      #    make test
+      - name: Read logs after bootup
+        run: |
+          docker-compose logs
+      - name: Stop services
+        run: |
+          docker-compose down

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,13 @@ docker-migrid
     :alt: Documentation Status
 |docsbadge|
 
+.. |cibadge| image:: https://github.com/benibr/docker-migrid/actions/workflows/ci.yml/badge.svg
+    :target: https://github.com/benibr/docker-migrid/actions/workflows/ci.yml
+    :alt: Continuous Integration
+|cibadge|
+
 A containerized version of the middleware `Minimum Intrusion Grid (MiG) <https://sourceforge.net/projects/migrid/>`_ system.
+Code also available on Github in the `migrid-sync <https://github.com/ucphhpc/migrid-sync>`_ repo.
 
 -----------------------------
 Documentation/Getting Started


### PR DESCRIPTION
This PR adds a basic Github Action to build and run the default container.

This is useful to test future changes to this repository and the tests from #21 could also be added.

I decided to use Github Actions because it's free to use and doesn't require any external infrastructure.