### PR TITLE
Makefile: added test-doc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
         uses: actions/checkout@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+      - name: Run tests for documentation
+        run: |
+          make test-doc
       - name: Build images
         run: |
           make init

--- a/doc/source/sections/configuration/variables.rst
+++ b/doc/source/sections/configuration/variables.rst
@@ -9,7 +9,6 @@ Below you can find a list of the available variable names.
 For further information you can have a look at the underlying `generateconfs.py <https://github.com/ucphhpc/migrid-sync/blob/master/mig/install/generateconfs.py>`
 
 
-
 Variables
 ---------
 
@@ -20,6 +19,39 @@ Variables
    * - Variable
      - Default
      - Notes
+   * - CONFIGPROXY_AUTH_TOKEN
+     - unset
+     - tba
+   * - CONTAINER_TAG
+     - ${MIG_GIT_BRANCH}
+     - The Docker tag used for the MiGrid image that is created. This might either be a Git tag, a MiGrid version or a arbitrary name.
+   * - FTPS_PASSIVE_PORTS
+     - 8100-8399
+     - The port range for FTPS passive ports used for data transmission.
+   * - JUPYTERHUB_CRYPT_KEY
+     - unset
+     - tba
+   * - ENABLE_LOGROTATE
+     - False
+     - Whether or not the logrotate service should be started inside the containers. Be aware that it also might be started through the #RUN_SERVICES variable in the docker-entry.sh.
+   * - LOGROTATE_MIGRID
+     - False
+     - Notes
+   * - MAIL_DOMAIN
+     - unset
+     - Notes
+   * - MIG_TEST_USER
+     - test@external.domain
+     - The username of the test user. Used by the development environments for tests.
+   * - MIG_TEST_USER_PASSWORD
+     - TestPw0rd
+     - The password for the test user. Used by the development environments for tests.
+   * - SMTP_SERVER
+     - localhost
+     - The MTA that is used to submit mails from migrid. Can be a hostname or an IP.
+   * - TZ
+     - Europe/Copenhagen
+     - The timezone that is used inside the containers.
    * - DOCKER_MIGRID_ROOT
      - .
      - Optionally use DOCKER_MIGRID_ROOT to point to another root location than PWD, which might be useful e.g. when automating deployment with ansible.


### PR DESCRIPTION
This PR adds a Makefile target for checking if all used env vars are documented in the variables section in the docs.

This is also checked in the CI pipeline on Github