### PR TITLE
Don't launch the entire stack on a regular make call

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ ifeq ("$(wildcard .env)",".env")
 include .env
 endif
 
-all: init dockerbuild up
+all: init dockerbuild
 
 init:	initbuild initdirs initcomposevars
 


### PR DESCRIPTION
I would prefer it, if we would not launch the stack on a regular ``make`` call.

To me, I would assume that `make` simply builds and prepares the stack for launching. Whereas launching/deploying it would be a separate active call, such as ``make up`` if the Makefile supports that.

Any objections to this? :) 