### PR TITLE
fixing make init loop & allow certs removal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,7 @@ clean:
 	rm -f docker-compose_shared.yml
 	rm -fr ./mig
 	rm -fr ./httpd
+	rm -fr ./certs
 
 stateclean: warning
 	rm -rf ./state
@@ -116,7 +117,6 @@ stateclean: warning
 #            Be careful NOT to use it on production systems!
 distclean: stateclean clean dockerclean
 	rm -fr ./external-certificates
-	rm -rf ./certs
 	rm -rf ./log
         # TODO: is something like this still needed to clean up completely?
         # It needs to NOT greedily remove ALL local volumes if so!

--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,9 @@ initdirs:
 	mkdir -p log/migrid-webdavs
 	mkdir -p log/migrid-ftps
 
-initcomposevars:	init
+initcomposevars:
 	@echo "creating env variable map in docker-compose_shared.yml"
+	@[ -f .env ] || echo "ERROR: no .env file found. Run 'make init' first."
 	@echo "$$DOCKER_COMPOSE_SHARED_HEADER" > docker-compose_shared.yml
 	@grep -v '\(^#.*\|^$$\)' .env >> docker-compose_shared.yml
 	@sed -E -i 's!^([^=]*)=.*!        - \1=\$$\{\1\}!' docker-compose_shared.yml
@@ -113,7 +114,7 @@ stateclean: warning
 # IMPORTANT: this target is meant to reset the dir to a pristine checkout
 #            and thus runs full clean up of even the state dir with user data
 #            Be careful NOT to use it on production systems!
-distclean: stateclean dockerclean clean
+distclean: stateclean clean dockerclean
 	rm -fr ./external-certificates
 	rm -rf ./certs
 	rm -rf ./log


### PR DESCRIPTION
This PR removes the `init` target from the `initcomposefile` target as it results in a loop. A subtarget should never call its parent. Instead an error message is displayed.

It also moves the `rm -rf ./certs` to the `clean` target. The way I see it, they should be removed if one calls make clean, like https confs and the application folder.