### PR TITLE
Setting ulimit for rsyslog

### DIFF
--- a/docker-entry.sh
+++ b/docker-entry.sh
@@ -132,7 +132,9 @@ for svc in ${RUN_SERVICES}; do
     elif [ "$svc" = "rsyslogd" ]; then
         # TODO: can we switch to proper service start?
         #service rsyslog start
-        /usr/sbin/rsyslogd
+        # limit the amout of open files for rsyslog due to
+        # https://github.com/rsyslog/rsyslog/issues/5158#issuecomment-1708760846
+        ( ulimit -n 1024; /usr/sbin/rsyslogd )
         status=$?
         if [ $status -ne 0 ]; then
             echo "Failed to start $svc: $status"


### PR DESCRIPTION
tl;dr

I experienced the problem that rsyslogd won't start inside the container. I spare you all the different workarounds, trial-on-errors, frustration and strace sessions. In the end it come down to ulimits. So this PR introduces a NOFILE=1024 for rsyslogd inside the docker containers.

The underlying problem is neither Migrid nor Docker but the fact that rsyslog preventively closes all possible file descriptors during startup. What the actual f**k!? On macOS and RHEL the limit usually equals ~1 billion. To try to close all those non open FDs it takes more that 60s, then rsyslogs kills itself because its child process doesn't respond. Well I guess that makes sense though. \
See detailed explanation and upstream fix: \
https://github.com/rsyslog/rsyslog/issues/5158#issuecomment-1708760846
https://github.com/rsyslog/rsyslog/pull/5230/files

Should be fixed in rsyslog `8.2310.0`. But on Rocky8 and Rocky9 `8.2102.0` is used.