### PR TITLE
made vgrid_files_readonly ro volume

### DIFF
--- a/docker-compose_development.yml
+++ b/docker-compose_development.yml
@@ -79,7 +79,10 @@ services:
         source: migrid-syslog
         target: /var/log
       # NOTE: for read-only vgrids/workgroups we need a local 'ro' bind-mount
-      - ./state/vgrid_files_writable:/home/mig/state/vgrid_files_readonly:ro
+      - type: volume
+        source: vgrid_files_readonly
+        target: /home/mig/state/vgrid_files_readonly
+        read_only: true
     env_file:
       - migrid-httpd.env
     # IMPORTANT: please ONLY run with this test@ user for non-public hosts
@@ -162,7 +165,10 @@ services:
         source: migrid-sftp-syslog
         target: /var/log
       # NOTE: for read-only vgrids/workgroups we need a local 'ro' bind-mount
-      - ./state/vgrid_files_writable:/home/mig/state/vgrid_files_readonly:ro
+      - type: volume
+        source: vgrid_files_readonly
+        target: /home/mig/state/vgrid_files_readonly
+        read_only: true
     command: /app/docker-entry.sh
 
   migrid-ftps:
@@ -202,7 +208,10 @@ services:
         source: migrid-ftps-syslog
         target: /var/log
       # NOTE: for read-only vgrids/workgroups we need a local 'ro' bind-mount
-      - ./state/vgrid_files_writable:/home/mig/state/vgrid_files_readonly:ro
+      - type: volume
+        source: vgrid_files_readonly
+        target: /home/mig/state/vgrid_files_readonly
+        read_only: true
     command: /app/docker-entry.sh
 
   migrid-webdavs:
@@ -241,7 +250,10 @@ services:
         source: migrid-webdavs-syslog
         target: /var/log
       # NOTE: for read-only vgrids/workgroups we need a local 'ro' bind-mount
-      - ./state/vgrid_files_writable:/home/mig/state/vgrid_files_readonly:ro
+      - type: volume
+        source: vgrid_files_readonly
+        target: /home/mig/state/vgrid_files_readonly
+        read_only: true
     command: /app/docker-entry.sh
 
   nginx-proxy:
@@ -311,6 +323,13 @@ volumes:
       device: ${DOCKER_MIGRID_ROOT}/state
       o: bind
   
+  vgrid_files_readonly:
+    driver: local
+    driver_opts:
+      type: none
+      device: ${DOCKER_MIGRID_ROOT}/state/vgrid_files_writable
+      o: "bind, ro"
+
   migrid-syslog:
     # Volume used for exposing migrid system log
     driver: local

--- a/docker-compose_production.yml
+++ b/docker-compose_production.yml
@@ -57,7 +57,7 @@ services:
         target: /var/log
       # NOTE: for read-only vgrids/workgroups we need a local 'ro' bind-mount
       - type: volume
-        source: state-ro
+        source: vgrid_files_readonly
         target: /home/mig/state/vgrid_files_readonly
         read_only: true
     env_file:
@@ -134,7 +134,7 @@ services:
         target: /var/log
       # NOTE: for read-only vgrids/workgroups we need a local 'ro' bind-mount
       - type: volume
-        source: state-ro
+        source: vgrid_files_readonly
         target: /home/mig/state/vgrid_files_readonly
         read_only: true
     command: /app/docker-entry.sh -k
@@ -173,7 +173,7 @@ services:
         target: /var/log
       # NOTE: for read-only vgrids/workgroups we need a local 'ro' bind-mount
       - type: volume
-        source: state-ro
+        source: vgrid_files_readonly
         target: /home/mig/state/vgrid_files_readonly
         read_only: true
     command: /app/docker-entry.sh -k
@@ -212,7 +212,7 @@ services:
         target: /var/log
       # NOTE: for read-only vgrids/workgroups we need a local 'ro' bind-mount
       - type: volume
-        source: state-ro
+        source: vgrid_files_readonly
         target: /home/mig/state/vgrid_files_readonly
         read_only: true
     command: /app/docker-entry.sh -k
@@ -272,7 +272,7 @@ volumes:
       device: ${DOCKER_MIGRID_ROOT}/state
       o: bind
   
-  state-ro:
+  vgrid_files_readonly:
     driver: local
     driver_opts:
       type: none

--- a/docker-compose_production.yml
+++ b/docker-compose_production.yml
@@ -56,7 +56,10 @@ services:
         source: migrid-syslog
         target: /var/log
       # NOTE: for read-only vgrids/workgroups we need a local 'ro' bind-mount
-      - ./state/vgrid_files_writable:/home/mig/state/vgrid_files_readonly:ro
+      - type: volume
+        source: state-ro
+        target: /home/mig/state/vgrid_files_readonly
+        read_only: true
     env_file:
       - migrid-httpd.env
     command: /app/docker-entry.sh -k -V
@@ -130,7 +133,10 @@ services:
         source: migrid-sftp-syslog
         target: /var/log
       # NOTE: for read-only vgrids/workgroups we need a local 'ro' bind-mount
-      - ./state/vgrid_files_writable:/home/mig/state/vgrid_files_readonly:ro
+      - type: volume
+        source: state-ro
+        target: /home/mig/state/vgrid_files_readonly
+        read_only: true
     command: /app/docker-entry.sh -k
 
   migrid-ftps:
@@ -166,7 +172,10 @@ services:
         source: migrid-ftps-syslog
         target: /var/log
       # NOTE: for read-only vgrids/workgroups we need a local 'ro' bind-mount
-      - ./state/vgrid_files_writable:/home/mig/state/vgrid_files_readonly:ro
+      - type: volume
+        source: state-ro
+        target: /home/mig/state/vgrid_files_readonly
+        read_only: true
     command: /app/docker-entry.sh -k
 
   migrid-webdavs:
@@ -202,7 +211,10 @@ services:
         source: migrid-webdavs-syslog
         target: /var/log
       # NOTE: for read-only vgrids/workgroups we need a local 'ro' bind-mount
-      - ./state/vgrid_files_writable:/home/mig/state/vgrid_files_readonly:ro
+      - type: volume
+        source: state-ro
+        target: /home/mig/state/vgrid_files_readonly
+        read_only: true
     command: /app/docker-entry.sh -k
 
 # NOTE: not used in stand-alone mode
@@ -260,6 +272,13 @@ volumes:
       device: ${DOCKER_MIGRID_ROOT}/state
       o: bind
   
+  state-ro:
+    driver: local
+    driver_opts:
+      type: none
+      device: ${DOCKER_MIGRID_ROOT}/state/vgrid_files_writable
+      o: bind
+
   migrid-syslog:
     # Volume used for exposing migrid system log
     driver: local

--- a/docker-compose_production.yml
+++ b/docker-compose_production.yml
@@ -277,7 +277,7 @@ volumes:
     driver_opts:
       type: none
       device: ${DOCKER_MIGRID_ROOT}/state/vgrid_files_writable
-      o: bind
+      o: "bind, ro"
 
   migrid-syslog:
     # Volume used for exposing migrid system log


### PR DESCRIPTION
The way the vgrid_files_readonly was implemented does not honor the way we use docker-compose.override in ansibl-docker-migrid, so now i have changed it so i can override the mountpoint correctly. 