### PR TITLE
Update Sphinx to specifically use 5.0.2

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,2 @@
-sphinx==4.3.2
+sphinx==5.0.2
 sphinx_rtd_theme==0.5.2


### PR DESCRIPTION
An attempt to fix the build failing, which gives the following error:
```
Running Sphinx v4.3.2
loading translations [en]... done

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/docker-migrid/envs/latest/lib/python3.10/site-packages/sphinx/registry.py", line 442, in load_extension
    metadata = setup(app)
  File "/home/docs/checkouts/readthedocs.org/user_builds/docker-migrid/envs/latest/lib/python3.10/site-packages/sphinxcontrib/applehelp/__init__.py", line 230, in setup
    app.require_sphinx('5.0')
  File "/home/docs/checkouts/readthedocs.org/user_builds/docker-migrid/envs/latest/lib/python3.10/site-packages/sphinx/application.py", line 407, in require_sphinx
    raise VersionRequirementError(version)
sphinx.errors.VersionRequirementError: 5.0

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/docker-migrid/envs/latest/lib/python3.10/site-packages/sphinx/cmd/build.py", line 276, in build_main
    app = Sphinx(args.sourcedir, args.confdir, args.outputdir,
  File "/home/docs/checkouts/readthedocs.org/user_builds/docker-migrid/envs/latest/lib/python3.10/site-packages/sphinx/application.py", line 233, in __init__
    self.setup_extension(extension)
  File "/home/docs/checkouts/readthedocs.org/user_builds/docker-migrid/envs/latest/lib/python3.10/site-packages/sphinx/application.py", line 394, in setup_extension
    self.registry.load_extension(self, extname)
  File "/home/docs/checkouts/readthedocs.org/user_builds/docker-migrid/envs/latest/lib/python3.10/site-packages/sphinx/registry.py", line 445, in load_extension
    raise VersionRequirementError(
sphinx.errors.VersionRequirementError: The sphinxcontrib.applehelp extension used by this project needs at least Sphinx v5.0; it therefore cannot be built with this version.

Sphinx version error:
The sphinxcontrib.applehelp extension used by this project needs at least Sphinx v5.0; it therefore cannot be built with this version.
```

As mentioned in https://github.com/sphinx-doc/sphinx/issues/11890, updating Sphinx to use 5.0.2 should satisfy applehelp without potentially introducing too many new errors from having a too new Sphinx.

Another potential fix is to let Sphinx be updated to its latest, but 5.0.2 seems a stable release to fix the relevant bug.