### PR TITLE
remove trailing slash from Docker volume targets

### DIFF
--- a/doc/source/sections/troubleshooting/containers.rst
+++ b/doc/source/sections/troubleshooting/containers.rst
@@ -39,3 +39,13 @@ DevDNS can't get IPs of containers
 
 This error occurs when DevDNS gets a notification of a container in another network.
 You can set the network in which DevDNS works with the environment variable `NETWORK=docker-migrid_default` for example.
+
+
+Docker Compose complains about volume paths
+-------------------------------------------
+
+::
+
+    Error response from daemon: invalid mount config for type "bind": invalid mount path: 'docker-migrid_httpd' mount path must be absolute
+
+This error message happens when Docker Compose V2 is used and a target path in one of the volumes contains a **trailing slash**

--- a/docker-compose_development.yml
+++ b/docker-compose_development.yml
@@ -65,7 +65,7 @@ services:
     volumes:
       - type: volume
         source: httpd
-        target: /etc/httpd/
+        target: /etc/httpd
       - type: volume
         source: mig
         target: /home/mig/mig
@@ -113,7 +113,7 @@ services:
     volumes:
       - type: volume
         source: httpd
-        target: /etc/httpd/
+        target: /etc/httpd
       - type: volume
         source: mig
         target: /home/mig/mig
@@ -151,7 +151,7 @@ services:
     volumes:
       - type: volume
         source: httpd
-        target: /etc/httpd/
+        target: /etc/httpd
       - type: volume
         source: mig
         target: /home/mig/mig
@@ -194,7 +194,7 @@ services:
     volumes:
       - type: volume
         source: httpd
-        target: /etc/httpd/
+        target: /etc/httpd
       - type: volume
         source: mig
         target: /home/mig/mig
@@ -236,7 +236,7 @@ services:
     volumes:
       - type: volume
         source: httpd
-        target: /etc/httpd/
+        target: /etc/httpd
       - type: volume
         source: mig
         target: /home/mig/mig

--- a/docker-compose_development_gdp.yml
+++ b/docker-compose_development_gdp.yml
@@ -65,7 +65,7 @@ services:
     volumes:
       - type: volume
         source: httpd
-        target: /etc/httpd/
+        target: /etc/httpd
       - type: volume
         source: mig
         target: /home/mig/mig
@@ -112,7 +112,7 @@ services:
     volumes:
       - type: volume
         source: httpd
-        target: /etc/httpd/
+        target: /etc/httpd
       - type: volume
         source: mig
         target: /home/mig/mig
@@ -150,7 +150,7 @@ services:
     volumes:
       - type: volume
         source: httpd
-        target: /etc/httpd/
+        target: /etc/httpd
       - type: volume
         source: mig
         target: /home/mig/mig
@@ -188,7 +188,7 @@ services:
     volumes:
       - type: volume
         source: httpd
-        target: /etc/httpd/
+        target: /etc/httpd
       - type: volume
         source: mig
         target: /home/mig/mig
@@ -225,7 +225,7 @@ services:
     volumes:
       - type: volume
         source: httpd
-        target: /etc/httpd/
+        target: /etc/httpd
       - type: volume
         source: mig
         target: /home/mig/mig

--- a/docker-compose_production.yml
+++ b/docker-compose_production.yml
@@ -42,7 +42,7 @@ services:
     volumes:
       - type: volume
         source: httpd
-        target: /etc/httpd/
+        target: /etc/httpd
       - type: volume
         source: mig
         target: /home/mig/mig
@@ -84,7 +84,7 @@ services:
     volumes:
       - type: volume
         source: httpd
-        target: /etc/httpd/
+        target: /etc/httpd
       - type: volume
         source: mig
         target: /home/mig/mig
@@ -119,7 +119,7 @@ services:
     volumes:
       - type: volume
         source: httpd
-        target: /etc/httpd/
+        target: /etc/httpd
       - type: volume
         source: mig
         target: /home/mig/mig
@@ -158,7 +158,7 @@ services:
     volumes:
       - type: volume
         source: httpd
-        target: /etc/httpd/
+        target: /etc/httpd
       - type: volume
         source: mig
         target: /home/mig/mig
@@ -197,7 +197,7 @@ services:
     volumes:
       - type: volume
         source: httpd
-        target: /etc/httpd/
+        target: /etc/httpd
       - type: volume
         source: mig
         target: /home/mig/mig


### PR DESCRIPTION
With the new docker compose version I get an error message saying

   Error response from daemon: invalid mount config for type "bind": invalid mount path: 'docker-migrid_httpd' mount path must be absolute

when the target path of a volume mount contains a trailing slash.

This PR remove the trailing slashes and adds a troubleshoot section to explain it.