### PR TITLE
Override default CSS to wrap text inside tables

### DIFF
--- a/doc/source/_static/css/custom.css
+++ b/doc/source/_static/css/custom.css
@@ -1,0 +1,4 @@
+.rst-content table.docutils td, .rst-content table.docutils th, .rst-content table.field-list td, 
+.rst-content table.field-list th, .wy-table td, .wy-table th {
+	text-wrap: wrap;
+}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -37,3 +37,4 @@ html_theme = 'sphinx_rtd_theme'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+html_css_files = ['css/custom.css']


### PR DESCRIPTION
Tested locally. Once custom CSS is active, tables should stay within content area with text wrapped. 

Link to an example of table that is affected:
https://docker-migrid.readthedocs.io/en/latest/sections/configuration/variables.html

The issue stems from the sphinx_rtd_theme, and there is a open issue in Read the Docs repo on GitHub:
`https://github.com/readthedocs/sphinx_rtd_theme/issues/1505`
Newer versions of the theme also seems to be affected.