### PR TITLE
Update the Makefile to use the dynamic ${DOCKER}  when executing compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ DOCKER = $(shell which docker || which podman)
 ifeq (, $(shell ${DOCKER} help|grep compose))
 	DOCKER_COMPOSE = $(shell which docker-compose || which podman-compose)
 else
-	DOCKER_COMPOSE = docker compose
+	DOCKER_COMPOSE = ${DOCKER} compose
 endif
 $(echo ${DOCKER_COMPOSE} >/dev/null)
 


### PR DESCRIPTION
Use the ${DOCKER} value when the shell check for whether the ${DOCKER} help output contains 'compose', which could be either docker or podman as per the dynamic lookup and not only docker