### PR TITLE
Adds the ability to specify which upstream container image registry should be used

### DIFF
--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -212,7 +212,7 @@ ARG JUPYTER_SERVICES=""
 ARG JUPYTER_SERVICES_DESC="{}"
 
 #------------------------- first stage -----------------------------#
-FROM --platform=linux/$ARCH centos:7 as init
+FROM --platform=linux/$ARCH centos:7 AS init
 ARG UID
 ARG GID
 ARG DOMAIN
@@ -273,7 +273,7 @@ RUN echo "Enable python3 support: $WITH_PY3"
 #RUN echo "Enable git checkout: $WITH_GIT"
 
 #------------------------- next stage -----------------------------#
-FROM --platform=linux/$ARCH init as base
+FROM --platform=linux/$ARCH init AS base
 ARG DOMAIN
 ARG WILDCARD_DOMAIN
 ARG ENABLE_GDP
@@ -580,7 +580,7 @@ RUN mkdir -p $CERT_DIR/MiG/${WILDCARD_DOMAIN} \
 
 #------------------------- next stage -----------------------------#
 # Certs and keys
-FROM --platform=linux/$ARCH base as setup_security
+FROM --platform=linux/$ARCH base AS setup_security
 ARG DOMAIN
 ARG WILDCARD_DOMAIN
 ARG PUBLIC_DOMAIN
@@ -687,7 +687,7 @@ WORKDIR $MIG_ROOT
 USER $USER
 
 #------------------------- next stage -----------------------------#
-FROM --platform=linux/$ARCH setup_security as mig_dependencies
+FROM --platform=linux/$ARCH setup_security AS mig_dependencies
 ARG DOMAIN
 ARG WITH_PY3
 ARG MODERN_WSGIDAV
@@ -849,7 +849,7 @@ RUN if [ "${WITH_PY3}" = "True" ]; then \
     fi;
 
 #------------------------- next stage -----------------------------#
-FROM --platform=linux/$ARCH mig_dependencies as download_mig
+FROM --platform=linux/$ARCH mig_dependencies AS download_mig
 LABEL MIGRID=true
 ARG DOMAIN
 ARG MIG_SVN_REPO
@@ -892,7 +892,7 @@ RUN if [ "${PREFER_PYTHON3}" = "True" -o "${MODERN_WSGIDAV}" = "True" ]; then \
 
 
 #------------------------- next stage -----------------------------#
-FROM --platform=linux/$ARCH download_mig as install_mig
+FROM --platform=linux/$ARCH download_mig AS install_mig
 ARG DOMAIN
 ARG PUBLIC_DOMAIN
 ARG MIGCERT_DOMAIN
@@ -1247,7 +1247,7 @@ RUN cd $MIG_ROOT && python2 mig/server/genoiddiscovery.py \
 
 
 #------------------------- next stage -----------------------------#
-FROM --platform=linux/$ARCH install_mig as setup_mig_configs
+FROM --platform=linux/$ARCH install_mig AS setup_mig_configs
 ARG DOMAIN
 ARG PUBLIC_DOMAIN
 ARG MIGCERT_DOMAIN
@@ -1459,7 +1459,7 @@ RUN if [ "${ENABLE_QUOTA}" = "True" ] \
         fi; \
     fi;
 #------------------------- next stage -----------------------------#
-FROM --platform=linux/$ARCH setup_mig_configs as start_mig
+FROM --platform=linux/$ARCH setup_mig_configs AS start_mig
 ARG DOMAIN
 
 # Reap defuncted/orphaned processes

--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -213,7 +213,7 @@ ARG JUPYTER_SERVICES=""
 ARG JUPYTER_SERVICES_DESC="{}"
 
 #------------------------- first stage -----------------------------#
-FROM --platform=linux/$ARCH rockylinux:8 as init
+FROM --platform=linux/$ARCH rockylinux:8 AS init
 ARG UID
 ARG GID
 ARG DOMAIN
@@ -274,7 +274,7 @@ RUN echo "Enable python3 support: $WITH_PY3"
 #RUN echo "Enable git checkout: $WITH_GIT"
 
 #------------------------- next stage -----------------------------#
-FROM --platform=linux/$ARCH init as base
+FROM --platform=linux/$ARCH init AS base
 ARG DOMAIN
 ARG WILDCARD_DOMAIN
 ARG ENABLE_GDP
@@ -589,7 +589,7 @@ RUN mkdir -p $CERT_DIR/MiG/${WILDCARD_DOMAIN} \
 
 #------------------------- next stage -----------------------------#
 # Certs and keys
-FROM --platform=linux/$ARCH base as setup_security
+FROM --platform=linux/$ARCH base AS setup_security
 ARG DOMAIN
 ARG WILDCARD_DOMAIN
 ARG PUBLIC_DOMAIN
@@ -696,7 +696,7 @@ WORKDIR $MIG_ROOT
 USER $USER
 
 #------------------------- next stage -----------------------------#
-FROM --platform=linux/$ARCH setup_security as mig_dependencies
+FROM --platform=linux/$ARCH setup_security AS mig_dependencies
 ARG DOMAIN
 ARG WITH_PY3
 ARG MODERN_WSGIDAV
@@ -859,7 +859,7 @@ RUN if [ "${WITH_PY3}" = "True" ]; then \
     fi;
 
 #------------------------- next stage -----------------------------#
-FROM --platform=linux/$ARCH mig_dependencies as download_mig
+FROM --platform=linux/$ARCH mig_dependencies AS download_mig
 LABEL MIGRID=true
 ARG DOMAIN
 ARG MIG_SVN_REPO
@@ -902,7 +902,7 @@ RUN if [ "${PREFER_PYTHON3}" = "True" -o "${MODERN_WSGIDAV}" = "True" ]; then \
 
 
 #------------------------- next stage -----------------------------#
-FROM --platform=linux/$ARCH download_mig as install_mig
+FROM --platform=linux/$ARCH download_mig AS install_mig
 ARG DOMAIN
 ARG PUBLIC_DOMAIN
 ARG MIGCERT_DOMAIN
@@ -1257,7 +1257,7 @@ RUN cd $MIG_ROOT && python mig/server/genoiddiscovery.py \
 
 
 #------------------------- next stage -----------------------------#
-FROM --platform=linux/$ARCH install_mig as setup_mig_configs
+FROM --platform=linux/$ARCH install_mig AS setup_mig_configs
 ARG DOMAIN
 ARG PUBLIC_DOMAIN
 ARG MIGCERT_DOMAIN
@@ -1475,7 +1475,7 @@ RUN if [ "${ENABLE_QUOTA}" = "True" ] \
         fi; \
     fi;
 #------------------------- next stage -----------------------------#
-FROM --platform=linux/$ARCH setup_mig_configs as start_mig
+FROM --platform=linux/$ARCH setup_mig_configs AS start_mig
 ARG DOMAIN
 
 # Reap defuncted/orphaned processes

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -213,7 +213,7 @@ ARG JUPYTER_SERVICES=""
 ARG JUPYTER_SERVICES_DESC="{}"
 
 #------------------------- first stage -----------------------------#
-FROM --platform=linux/$ARCH rockylinux:9 as init
+FROM --platform=linux/$ARCH rockylinux:9 AS init
 ARG UID
 ARG GID
 ARG DOMAIN
@@ -544,7 +544,7 @@ RUN mkdir -p $CERT_DIR/MiG/${WILDCARD_DOMAIN} \
 
 #------------------------- next stage -----------------------------#
 # Certs and keys
-FROM --platform=linux/$ARCH base as setup_security
+FROM --platform=linux/$ARCH base AS setup_security
 ARG DOMAIN
 ARG WILDCARD_DOMAIN
 ARG PUBLIC_DOMAIN
@@ -649,7 +649,7 @@ WORKDIR $MIG_ROOT
 USER $USER
 
 #------------------------- next stage -----------------------------#
-FROM --platform=linux/$ARCH setup_security as mig_dependencies
+FROM --platform=linux/$ARCH setup_security AS mig_dependencies
 ARG DOMAIN
 ARG WITH_PY3
 ARG MODERN_WSGIDAV
@@ -764,7 +764,7 @@ RUN if [ "${WITH_PY3}" = "True" ]; then \
     fi;
 
 #------------------------- next stage -----------------------------#
-FROM --platform=linux/$ARCH mig_dependencies as download_mig
+FROM --platform=linux/$ARCH mig_dependencies AS download_mig
 LABEL MIGRID=true
 ARG DOMAIN
 ARG MIG_SVN_REPO
@@ -802,7 +802,7 @@ RUN rm -f ${MIG_ROOT}/mig/server/grid_webdavs.py ; \
 
 
 #------------------------- next stage -----------------------------#
-FROM --platform=linux/$ARCH download_mig as install_mig
+FROM --platform=linux/$ARCH download_mig AS install_mig
 ARG DOMAIN
 ARG PUBLIC_DOMAIN
 ARG MIGCERT_DOMAIN
@@ -1143,7 +1143,7 @@ RUN cd $MIG_ROOT && python mig/server/genoiddiscovery.py \
 
 
 #------------------------- next stage -----------------------------#
-FROM --platform=linux/$ARCH install_mig as setup_mig_configs
+FROM --platform=linux/$ARCH install_mig AS setup_mig_configs
 ARG DOMAIN
 ARG PUBLIC_DOMAIN
 ARG MIGCERT_DOMAIN
@@ -1355,7 +1355,7 @@ RUN if [ "${ENABLE_QUOTA}" = "True" ] \
         fi; \
     fi;
 #------------------------- next stage -----------------------------#
-FROM --platform=linux/$ARCH setup_mig_configs as start_mig
+FROM --platform=linux/$ARCH setup_mig_configs AS start_mig
 ARG DOMAIN
 
 # Reap defuncted/orphaned processes

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,20 @@ dockerclean: initcomposevars
 logs:	initcomposevars
 	${DOCKER_COMPOSE} logs
 
-dockerpush:
+
+dockerpushwarning:
+	@if [ "${CONTAINER_REGISTRY}" == "docker.io" ]; then \
+		echo
+		echo "*** WARNING ***"
+		echo "*** Pushing to docker.io ***"
+		echo "*** This will make the $(OWNER)/$(IMAGE)${CONTAINER_TAG} image publicly available ***"
+		echo "*** Any secrets in the $(OWNER)/$(IMAGE)${CONTAINER_TAG} image, such as passwords/salts set via environment variables/file(s), will be exposed ***"
+		echo "*** Make sure that the $(OWNER)/$(IMAGE)${CONTAINER_TAG} image does not contain any such secrets before proceeding ***"
+		echo
+		echo "Are you sure you want to push $(OWNER)/$(IMAGE)${CONTAINER_TAG} to ${CONTAINER_REGISTRY}? [y/N]" && read ans && [ $${ans:-N} = y ]; \
+	fi
+
+dockerpush: dockerpushwarning
 	${DOCKER} push ${CONTAINER_REGISTRY}/$(OWNER)/$(IMAGE)${CONTAINER_TAG}
 
 dockervolumeclean:

--- a/development.env
+++ b/development.env
@@ -3,6 +3,10 @@
 #            make your desired changes before running
 #            make init && make build
 
+# This can be used to specify custom upstream registries
+# from where to pull/push the docker-migrid stack images
+CONTAINER_REGISTRY=${CONTAINER_REGISTRY:-docker.io}
+
 # Optionally use DOCKER_MIGRID_ROOT to point to another root location than PWD,
 # which might be useful e.g. when automating deployment with ansible.
 # IMPORTANT: with docker on centos7 RO-mounts may fail unless we use an abs path

--- a/development_gdp.env
+++ b/development_gdp.env
@@ -3,6 +3,10 @@
 #            make your desired changes before running
 #            make init && make build
 
+# This can be used to specify custom upstream registries
+# from where to pull/push the docker-migrid stack images
+CONTAINER_REGISTRY=${CONTAINER_REGISTRY:-docker.io}
+
 # Optionally use DOCKER_MIGRID_ROOT to point to another root location than PWD,
 # which might be useful e.g. when automating deployment with ansible.
 # IMPORTANT: with docker on centos7 RO-mounts may fail unless we use an abs path

--- a/doc/source/sections/configuration/variables.rst
+++ b/doc/source/sections/configuration/variables.rst
@@ -19,6 +19,9 @@ Variables
    * - Variable
      - Default
      - Notes
+   * - CONTAINER_REGISTRY
+     - docker.io
+     - The upstream container image registry to use when deploying/pushing the Docker MiGrid Stack.
    * - CONTAINER_TAG
      - ${MIG_GIT_BRANCH}
      - The Docker tag used for the MiGrid image that is created. This might either be a Git tag, a MiGrid version or a arbitrary name.

--- a/docker-compose_development.yml
+++ b/docker-compose_development.yml
@@ -3,7 +3,7 @@ version: '3.7'
 
 services:
   devmail:
-    image: mwader/postfix-relay
+    image: ${CONTAINER_REGISTRY}/mwader/postfix-relay
     container_name: devmail
     depends_on:
       - devdns
@@ -17,7 +17,7 @@ services:
           - mail.migrid.test
 
   devdns:
-    image: ruudud/devdns
+    image: ${CONTAINER_REGISTRY}/ruudud/devdns
     container_name: devdns
     ports:
         - "127.0.0.1:53:53/udp"
@@ -32,7 +32,7 @@ services:
   #       subdirs from e.g. the state volume in the service containers.
   migrid-volume-init:
     container_name: migrid-volume-init
-    image: ucphhpc/migrid${CONTAINER_TAG}
+    image: ${CONTAINER_REGISTRY}/ucphhpc/migrid${CONTAINER_TAG}
     extends:
       file: docker-compose_shared.yml
       service: migrid-shared
@@ -78,7 +78,7 @@ services:
 
   migrid:
     container_name: migrid
-    image: ucphhpc/migrid${CONTAINER_TAG}
+    image: ${CONTAINER_REGISTRY}/ucphhpc/migrid${CONTAINER_TAG}
     extends:
       file: docker-compose_shared.yml
       service: migrid-shared
@@ -143,7 +143,7 @@ services:
   # Multiple containers with individual daemons not provided by base migrid
   migrid-openid:
     container_name: migrid-openid
-    image: ucphhpc/migrid${CONTAINER_TAG}
+    image: ${CONTAINER_REGISTRY}/ucphhpc/migrid${CONTAINER_TAG}
     environment:
       TZ: ${TZ}
       # RUN_SERVICES specifies which daemons to launch
@@ -185,7 +185,7 @@ services:
 
   migrid-sftp:
     container_name: migrid-sftp
-    image: ucphhpc/migrid${CONTAINER_TAG}
+    image: ${CONTAINER_REGISTRY}/ucphhpc/migrid${CONTAINER_TAG}
     environment:
       TZ: ${TZ}
       # RUN_SERVICES specifies which daemons to launch
@@ -232,7 +232,7 @@ services:
 
   migrid-ftps:
     container_name: migrid-ftps
-    image: ucphhpc/migrid${CONTAINER_TAG}
+    image: ${CONTAINER_REGISTRY}/ucphhpc/migrid${CONTAINER_TAG}
     environment:
       TZ: ${TZ}
       # RUN_SERVICES specifies which daemons to launch
@@ -279,7 +279,7 @@ services:
 
   migrid-webdavs:
     container_name: migrid-webdavs
-    image: ucphhpc/migrid${CONTAINER_TAG}
+    image: ${CONTAINER_REGISTRY}/ucphhpc/migrid${CONTAINER_TAG}
     environment:
       TZ: ${TZ}
       # RUN_SERVICES specifies which daemons to launch
@@ -324,7 +324,7 @@ services:
     command: /app/docker-entry.sh
 
   nginx-proxy:
-    image: jwilder/nginx-proxy
+    image: ${CONTAINER_REGISTRY}/jwilder/nginx-proxy
     container_name: nginx-proxy
     # TODO: can we add an httpd health check and switch to wait for condition
     #       service_healthy to avoid the storm of initial avoid nginx errors

--- a/docker-compose_development_gdp.yml
+++ b/docker-compose_development_gdp.yml
@@ -3,7 +3,7 @@ version: '3.7'
 
 services:
   devmail:
-    image: mwader/postfix-relay
+    image: ${CONTAINER_REGISTRY}/mwader/postfix-relay
     container_name: devmail
     depends_on:
       - devdns
@@ -17,7 +17,7 @@ services:
           - mail.migrid.test
 
   devdns:
-    image: ruudud/devdns
+    image: ${CONTAINER_REGISTRY}/ruudud/devdns
     container_name: devdns
     ports:
         - "127.0.0.1:53:53/udp"
@@ -32,7 +32,7 @@ services:
   #       subdirs from e.g. the state volume in the service containers.
   migrid-volume-init:
     container_name: migrid-volume-init
-    image: ucphhpc/migrid${CONTAINER_TAG}
+    image: ${CONTAINER_REGISTRY}/ucphhpc/migrid${CONTAINER_TAG}
     extends:
       file: docker-compose_shared.yml
       service: migrid-shared
@@ -78,7 +78,7 @@ services:
 
   migrid:
     container_name: migrid
-    image: ucphhpc/migrid${CONTAINER_TAG}
+    image: ${CONTAINER_REGISTRY}/ucphhpc/migrid${CONTAINER_TAG}
     extends:
       file: docker-compose_shared.yml
       service: migrid-shared
@@ -147,7 +147,7 @@ services:
   # Multiple containers with individual daemons not provided by base migrid
   migrid-openid:
     container_name: migrid-openid
-    image: ucphhpc/migrid${CONTAINER_TAG}
+    image: ${CONTAINER_REGISTRY}/ucphhpc/migrid${CONTAINER_TAG}
     environment:
       TZ: ${TZ}
       # RUN_SERVICES specifies which daemons to launch
@@ -189,7 +189,7 @@ services:
 
   migrid-sftp:
     container_name: migrid-sftp
-    image: ucphhpc/migrid${CONTAINER_TAG}
+    image: ${CONTAINER_REGISTRY}/ucphhpc/migrid${CONTAINER_TAG}
     environment:
       TZ: ${TZ}
       # RUN_SERVICES specifies which daemons to launch
@@ -236,7 +236,7 @@ services:
 
   migrid-ftps:
     container_name: migrid-ftps
-    image: ucphhpc/migrid${CONTAINER_TAG}
+    image: ${CONTAINER_REGISTRY}/ucphhpc/migrid${CONTAINER_TAG}
     environment:
       TZ: ${TZ}
       # RUN_SERVICES specifies which daemons to launch
@@ -283,7 +283,7 @@ services:
 
   migrid-webdavs:
     container_name: migrid-webdavs
-    image: ucphhpc/migrid${CONTAINER_TAG}
+    image: ${CONTAINER_REGISTRY}/ucphhpc/migrid${CONTAINER_TAG}
     environment:
       TZ: ${TZ}
       # RUN_SERVICES specifies which daemons to launch
@@ -328,7 +328,9 @@ services:
     command: /app/docker-entry.sh
 
   nginx-proxy:
-    image: jwilder/nginx-proxy
+    image: ${CONTAINER_REGISTRY}/jwilder/nginx-proxy
+    environment:
+      TZ: ${TZ}
     container_name: nginx-proxy
     # TODO: can we add an httpd health check and switch to wait for condition
     #       service_healthy to avoid the storm of initial avoid nginx errors

--- a/docker-compose_production.yml
+++ b/docker-compose_production.yml
@@ -4,7 +4,7 @@ version: '3.7'
 services:
 # NOTE: not used in stand-alone mode
 #  devdns:
-#    image: ruudud/devdns
+#    image: ${CONTAINER_REGISTRY}/ruudud/devdns
 #    container_name: devdns
 #    ports:
 #        - "127.0.0.1:53:53/udp"
@@ -27,7 +27,7 @@ services:
 
   migrid:
     container_name: migrid
-    image: ucphhpc/migrid${CONTAINER_TAG}
+    image: ${CONTAINER_REGISTRY}/ucphhpc/migrid${CONTAINER_TAG}
     network_mode: "host"
     extends:
       file: docker-compose_shared.yml
@@ -75,7 +75,7 @@ services:
   # Multiple containers with individual daemons not provided by base migrid
   migrid-openid:
     container_name: migrid-openid
-    image: ucphhpc/migrid${CONTAINER_TAG}
+    image: ${CONTAINER_REGISTRY}/ucphhpc/migrid${CONTAINER_TAG}
     network_mode: "host"
     environment:
       TZ: ${TZ}
@@ -114,7 +114,7 @@ services:
 
   migrid-sftp:
     container_name: migrid-sftp
-    image: ucphhpc/migrid${CONTAINER_TAG}
+    image: ${CONTAINER_REGISTRY}/ucphhpc/migrid${CONTAINER_TAG}
     network_mode: "host"
     environment:
       TZ: ${TZ}
@@ -158,7 +158,7 @@ services:
 
   migrid-ftps:
     container_name: migrid-ftps
-    image: ucphhpc/migrid${CONTAINER_TAG}
+    image: ${CONTAINER_REGISTRY}/ucphhpc/migrid${CONTAINER_TAG}
     network_mode: "host"
     environment:
       TZ: ${TZ}
@@ -201,7 +201,7 @@ services:
 
   migrid-webdavs:
     container_name: migrid-webdavs
-    image: ucphhpc/migrid${CONTAINER_TAG}
+    image: ${CONTAINER_REGISTRY}/ucphhpc/migrid${CONTAINER_TAG}
     network_mode: "host"
     environment:
       TZ: ${TZ}
@@ -244,7 +244,7 @@ services:
 
 # NOTE: not used in stand-alone production mode
 #  nginx-proxy:
-#    image: jwilder/nginx-proxy
+#    image: ${CONTAINER_REGISTRY}/jwilder/nginx-proxy
 #    container_name: nginx-proxy
 #    network_mode: "host"
 #    # TODO: can we add an httpd health check and switch to wait for condition

--- a/docker-compose_production_bind.yml
+++ b/docker-compose_production_bind.yml
@@ -4,7 +4,7 @@ version: '3.7'
 services:
 # NOTE: not used in stand-alone mode
 #  devdns:
-#    image: ruudud/devdns
+#    image: ${CONTAINER_REGISTRY}/ruudud/devdns
 #    container_name: devdns
 #    ports:
 #        - "127.0.0.1:53:53/udp"
@@ -22,7 +22,7 @@ services:
   #       while lustre is mounted.
   migrid-volume-init:
     container_name: migrid-volume-init
-    image: ucphhpc/migrid${CONTAINER_TAG}
+    image: ${CONTAINER_REGISTRY}/ucphhpc/migrid${CONTAINER_TAG}
     network_mode: "host"
     extends:
       file: docker-compose_shared.yml
@@ -69,7 +69,7 @@ services:
 
   migrid:
     container_name: migrid
-    image: ucphhpc/migrid${CONTAINER_TAG}
+    image: ${CONTAINER_REGISTRY}/ucphhpc/migrid${CONTAINER_TAG}
     network_mode: "host"
     extends:
       file: docker-compose_shared.yml
@@ -122,7 +122,7 @@ services:
   # Multiple containers with individual daemons not provided by base migrid
   migrid-openid:
     container_name: migrid-openid
-    image: ucphhpc/migrid${CONTAINER_TAG}
+    image: ${CONTAINER_REGISTRY}/ucphhpc/migrid${CONTAINER_TAG}
     network_mode: "host"
     environment:
       TZ: ${TZ}
@@ -161,7 +161,7 @@ services:
 
   migrid-sftp:
     container_name: migrid-sftp
-    image: ucphhpc/migrid${CONTAINER_TAG}
+    image: ${CONTAINER_REGISTRY}/ucphhpc/migrid${CONTAINER_TAG}
     network_mode: "host"
     environment:
       TZ: ${TZ}
@@ -205,7 +205,7 @@ services:
 
   migrid-ftps:
     container_name: migrid-ftps
-    image: ucphhpc/migrid${CONTAINER_TAG}
+    image: ${CONTAINER_REGISTRY}/ucphhpc/migrid${CONTAINER_TAG}
     network_mode: "host"
     environment:
       TZ: ${TZ}
@@ -248,7 +248,7 @@ services:
 
   migrid-webdavs:
     container_name: migrid-webdavs
-    image: ucphhpc/migrid${CONTAINER_TAG}
+    image: ${CONTAINER_REGISTRY}/ucphhpc/migrid${CONTAINER_TAG}
     network_mode: "host"
     environment:
       TZ: ${TZ}
@@ -291,7 +291,7 @@ services:
 
 # NOTE: not used in stand-alone production mode
 #  nginx-proxy:
-#    image: jwilder/nginx-proxy
+#    image: ${CONTAINER_REGISTRY}/jwilder/nginx-proxy
 #    container_name: nginx-proxy
 #    network_mode: "host"
 #    # TODO: can we add an httpd health check and switch to wait for condition

--- a/production.env
+++ b/production.env
@@ -3,6 +3,10 @@
 #            make your desired changes before running
 #            make init && make build
 
+# This can be used to specify custom upstream registries
+# from where to pull/push the docker-migrid stack images
+CONTAINER_REGISTRY=${CONTAINER_REGISTRY:-docker.io}
+
 # Optionally use DOCKER_MIGRID_ROOT to point to another root location than PWD,
 # which might be useful e.g. when automating deployment with ansible.
 # IMPORTANT: with docker on centos7 RO-mounts may fail unless we use an abs path


### PR DESCRIPTION
This introduces the CONTAINER_REGISTRY variable that can be used to specify which upstream container image registry to use when deploying/building/pushing the docker-migrid stack. This variable can be specified either through the linked environment file, or as an argument when calling make. It defaults to the DockerHub container registry, namely docker.io.

In addition, it also does a bit of format correction to comply with https://docs.docker.com/reference/build-checks/from-as-casing/ to use consistent casing in the FROM --platform statements and thereby remove the build warnings that they throw.

Furthermore, it renames the `ARGS` variable for the `dockerbuild` make target to `BUILD_ARGS` to make it more explicit which target it can be used for.