### PR TITLE
Switch default make init from CentOS7 to Rocky9 container if pristine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,9 +60,9 @@ init:	initbuild initdirs initcomposevars
 initbuild:
 ifeq (,$(wildcard ./Dockerfile))
 	@echo
-	@echo "*** No Dockerfile selected - defaulting to centos7 ***"
+	@echo "*** No Dockerfile selected - defaulting to rocky9 ***"
 	@echo
-	ln -s Dockerfile.centos7 Dockerfile
+	ln -s Dockerfile.rocky9 Dockerfile
 	@sleep 2
 endif
 ifeq (,$(wildcard ./.env))
@@ -197,7 +197,7 @@ distclean: stateclean clean dockerclean dockervolumeclean
 	rm -rf ./log
 	# NOTE: certs remove in clean is conditional - always remove it here
 	rm -fr ./certs
-	rm -f .env docker-compose.yml
+	rm -f .env docker-compose.yml Dockerfile
 
 warning:
 	@echo


### PR DESCRIPTION
Change the default `Dockerfile` symlink from the now deprecated `Dockerfile.centos7` to `Dockerfile.rocky9` in the 'make init' case from a pristine / distclean state. It's mostly only relevant for local development setups and should not make any difference for real sites as we expect them to explicitly init all three site setup files `(.env`, `docker-compose.yml` and `Dockerfile`) ahead of `make`.
Add the `Dockerfile` symlink to the 'make distclean' clean up while at it.