### PR TITLE
Update badges on README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,10 +7,9 @@ docker-migrid
     :alt: Documentation Status
 |docsbadge|
 
-.. |cibadge| image:: https://github.com/benibr/docker-migrid/actions/workflows/ci.yml/badge.svg
-    :target: https://github.com/ucphhpc/docker-migrid/actions/workflows/ci.yml
-    :alt: Continuous Integration
-|cibadge|
+[![Continuous Integration](https://github.com/ucphhpc/docker-migrid/actions/workflows/ci.yml/badge.svg)](https://github.com/ucphhpc/docker-migrid/actions/workflows/ci.yml)
+
+[![Continuous Integration - Legacy](https://github.com/ucphhpc/docker-migrid/actions/workflows/ci-legacy.yml/badge.svg)](https://github.com/ucphhpc/docker-migrid/actions/workflows/ci-legacy.yml)
 
 A containerized version of the middleware `Minimum Intrusion Grid (MiG) <https://sourceforge.net/projects/migrid/>`_ system.
 Code also available on Github in the `migrid-sync <https://github.com/ucphhpc/migrid-sync>`_ repo.


### PR DESCRIPTION
Update old link to benibr's personal fork of the repo for the README CI badge and add a corresponding CI Legacy badge.