### PR TITLE
Restructure volumes and disk layout for state init to work for the production example

### DIFF
--- a/.github/workflows/ci-legacy.yml
+++ b/.github/workflows/ci-legacy.yml
@@ -46,9 +46,9 @@ jobs:
           make test-doc
       - name: Build images
         run: |
-          ln -s Dockerfile.${{ matrix.container_os }} Dockerfile
-          ln -s docker-compose_${{ matrix.environment_profile }}.yml docker-compose.yml
-          ln -s ${{ matrix.environment_profile }}.env .env
+          ln -s -f Dockerfile.${{ matrix.container_os }} Dockerfile
+          ln -s -f docker-compose_${{ matrix.environment_profile }}.yml docker-compose.yml
+          ln -s -f ${{ matrix.environment_profile }}.env .env
           make init
           echo "# NOTE: use absolute paths to current dir to get docker bind mounts to work" > ci.env
           echo "DOCKER_MIGRID_ROOT=$PWD" >> ci.env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,9 @@ jobs:
           make test-doc
       - name: Build images
         run: |
-          ln -s Dockerfile.${{ matrix.container_os }} Dockerfile
-          ln -s docker-compose_${{ matrix.environment_profile }}.yml docker-compose.yml
-          ln -s ${{ matrix.environment_profile }}.env .env
+          ln -s -f Dockerfile.${{ matrix.container_os }} Dockerfile
+          ln -s -f docker-compose_${{ matrix.environment_profile }}.yml docker-compose.yml
+          ln -s -f ${{ matrix.environment_profile }}.env .env
           make init
           echo "# NOTE: use absolute paths to current dir to get docker bind mounts to work" > ci.env
           echo "DOCKER_MIGRID_ROOT=$PWD" >> ci.env

--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,7 @@ docker-compose.override.yml
 migrid-httpd-init.sh
 MiG-certificates
 certs
+.migrid_enabled_services
+sitetmp
+sitelogs
+sitedata

--- a/.spellcheck-wordlist.txt
+++ b/.spellcheck-wordlist.txt
@@ -352,3 +352,4 @@ wsgi
 PROCS
 procs
 WWWSERVE
+tmp

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -1300,6 +1300,9 @@ RUN cp generated-confs/MiGserver.conf $MIG_ROOT/mig/server/ \
     && cp generated-confs/index.html $MIG_ROOT/state/user_home/ \
     && cp $MIG_ROOT/mig/images/site-conf-${EMULATE_FQDN}.js $MIG_ROOT/mig/images/site-conf.js
 
+# Add a couple of named pipes for communicating with grid_X daemons
+RUN cd $MIG_ROOT && mkfifo mig/server/server.stdin && mkfifo mig/server/notify.stdin
+
 # Prepare oiddiscover for httpd
 RUN cd $MIG_ROOT && python2 mig/server/genoiddiscovery.py \
     > $MIG_ROOT/state/wwwpublic/oiddiscover.xml

--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -1317,6 +1317,9 @@ RUN cp generated-confs/MiGserver.conf $MIG_ROOT/mig/server/ \
     && cp generated-confs/index.html $MIG_ROOT/state/user_home/ \
     && cp $MIG_ROOT/mig/images/site-conf-${EMULATE_FQDN}.js $MIG_ROOT/mig/images/site-conf.js
 
+# Add a couple of named pipes for communicating with grid_X daemons
+RUN cd $MIG_ROOT && mkfifo mig/server/server.stdin && mkfifo mig/server/notify.stdin
+
 # Prepare oiddiscover for httpd
 RUN cd $MIG_ROOT && python mig/server/genoiddiscovery.py \
     > $MIG_ROOT/state/wwwpublic/oiddiscover.xml

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -1198,6 +1198,9 @@ RUN cp generated-confs/MiGserver.conf $MIG_ROOT/mig/server/ \
     && cp generated-confs/index.html $MIG_ROOT/state/user_home/ \
     && cp $MIG_ROOT/mig/images/site-conf-${EMULATE_FQDN}.js $MIG_ROOT/mig/images/site-conf.js
 
+# Add a couple of named pipes for communicating with grid_X daemons
+RUN cd $MIG_ROOT && mkfifo mig/server/server.stdin && mkfifo mig/server/notify.stdin
+
 # Prepare oiddiscover for httpd
 RUN cd $MIG_ROOT && python mig/server/genoiddiscovery.py \
     > $MIG_ROOT/state/wwwpublic/oiddiscover.xml

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,26 @@ initdirs:
 	mkdir -p httpd
 	mkdir -p mig
 	mkdir -p state
+	mkdir -p volatile/mig_system_run
+	mkdir -p volatile/openid_store
+	mkdir -p persistent/freeze_home
+	mkdir -p persistent/mrsl_files
+	mkdir -p persistent/resource_home
+	mkdir -p persistent/secrets
+	mkdir -p persistent/sharelink_home
+	mkdir -p persistent/sss_home
+	mkdir -p persistent/user_db_home
+	mkdir -p persistent/user_home
+	mkdir -p persistent/user_settings
+	mkdir -p persistent/vgrid_files_home
+	mkdir -p persistent/vgrid_files_readonly
+	mkdir -p persistent/vgrid_files_writable
+	mkdir -p persistent/vgrid_home
+	mkdir -p persistent/vgrid_private_base
+	mkdir -p persistent/vgrid_public_base
+	mkdir -p persistent/wwwpublic-archives
+	mkdir -p persistent/wwwpublic-vgrids
+	mkdir -p log/miglog
 	mkdir -p log/migrid
 	mkdir -p log/migrid-io
 	mkdir -p log/migrid-openid
@@ -187,10 +207,14 @@ clean:
 	[ -L ./certs ] || [ -f ./certs/.persistent ] || rm -fr ./certs
 
 stateclean: warning
-	rm -rf ./state
+	umount ./persistent > /dev/null 2>&1 || true
+	umount ./persistent/* > /dev/null 2>&1 || true
+	umount ./volatile > /dev/null 2>&1 || true
+	umount ./volatile/* > /dev/null 2>&1 || true
+	rm -rf ./state ./volatile ./persistent
 
 # IMPORTANT: this target is meant to reset the dir to a pristine checkout
-#            and thus runs full clean up of even the state dir with user data
+#            and thus runs full clean up of even the state dirs with user data
 #            Be careful NOT to use it on production systems!
 distclean: stateclean clean dockerclean dockervolumeclean
 	rm -fr ./external-certificates

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ docker-compose.yml:
 	ln -s docker-compose_development.yml docker-compose.yml
 	@sleep 2
 
-migrid-httpd-init:
+migrid-httpd-init.sh:
 	sed 's@#unset @unset @g;s@#export @export @g' migrid-httpd.env > migrid-httpd-init.sh
 
 initdirs: initcomposevars

--- a/development.env
+++ b/development.env
@@ -12,6 +12,13 @@ CONTAINER_REGISTRY=${CONTAINER_REGISTRY:-docker.io}
 # IMPORTANT: with docker on centos7 RO-mounts may fail unless we use an abs path
 DOCKER_MIGRID_ROOT=.
 
+# Helper storage locations as subdirs in DOCKER_MIGRID_ROOT by default
+# On real production sites you probably want to store them elsewhere on
+# scalable storage.
+LOG_ROOT=${DOCKER_MIGRID_ROOT}/sitelogs
+PERSISTENT_ROOT=${DOCKER_MIGRID_ROOT}/sitedata
+VOLATILE_ROOT=${DOCKER_MIGRID_ROOT}/sitetmp
+
 # Set to override container user and group IDs
 #UID=1000
 #GID=1000

--- a/development_gdp.env
+++ b/development_gdp.env
@@ -12,6 +12,13 @@ CONTAINER_REGISTRY=${CONTAINER_REGISTRY:-docker.io}
 # IMPORTANT: with docker on centos7 RO-mounts may fail unless we use an abs path
 DOCKER_MIGRID_ROOT=.
 
+# Helper storage locations as subdirs in DOCKER_MIGRID_ROOT by default
+# On real production sites you probably want to store them elsewhere on
+# scalable storage.
+LOG_ROOT=${DOCKER_MIGRID_ROOT}/sitelogs
+PERSISTENT_ROOT=${DOCKER_MIGRID_ROOT}/sitedata
+VOLATILE_ROOT=${DOCKER_MIGRID_ROOT}/sitetmp
+
 # Set to override container user and group IDs
 #UID=1000
 #GID=1000

--- a/doc/source/sections/configuration/variables.rst
+++ b/doc/source/sections/configuration/variables.rst
@@ -54,13 +54,13 @@ Variables
      - Optionally use to point to another installation location than `PWD`, which might be useful e.g. when automating deployment with ansible.
    * - LOG_ROOT
      - log
-     - Optionally use to point to another site log location than `log` subdir of `$DOCKER_MIGRID_ROOT`, which might be useful e.g. when storing logs on network storage or separate partitions/disks.
+     - Optionally use to point to another site log location than `log` directory in `$DOCKER_MIGRID_ROOT`, which might be useful e.g. when storing logs on network storage or separate partitions/disks.
    * - PERSISTENT_ROOT
      - persistent
-     - Optionally use to point to another site data location than `persistent` subdir of `$DOCKER_MIGRID_ROOT`, which might be useful e.g. when storing persistent site data on network storage or separate partitions/disks.
+     - Optionally use to point to another site data location than `persistent` directory in `$DOCKER_MIGRID_ROOT`, which might be useful e.g. when storing persistent site data on network storage or separate partitions/disks.
    * - VOLATILE_ROOT
      - volatile
-     - Optionally use to point to another site tmp location than `volatile` subdir of `$DOCKER_MIGRID_ROOT`, which might be useful e.g. when storing logs on network storage or separate partitions/disks.
+     - Optionally use to point to another site tmp location than `volatile` directory in `$DOCKER_MIGRID_ROOT`, which might be useful e.g. when storing logs on network storage or separate partitions/disks.
    * - UID
      - 1000
      - User ID of the migrid user inside the container, which might be useful to avoid various permission errors when juggling data inside and outside containers.

--- a/doc/source/sections/configuration/variables.rst
+++ b/doc/source/sections/configuration/variables.rst
@@ -51,7 +51,16 @@ Variables
      - The timezone that is used inside the containers.
    * - DOCKER_MIGRID_ROOT
      - .
-     - Optionally use DOCKER_MIGRID_ROOT to point to another root location than PWD, which might be useful e.g. when automating deployment with ansible.
+     - Optionally use to point to another installation location than `PWD`, which might be useful e.g. when automating deployment with ansible.
+   * - LOG_ROOT
+     - log
+     - Optionally use to point to another site log location than `log` subdir of `$DOCKER_MIGRID_ROOT`, which might be useful e.g. when storing logs on network storage or separate partitions/disks.
+   * - PERSISTENT_ROOT
+     - persistent
+     - Optionally use to point to another site data location than `persistent` subdir of `$DOCKER_MIGRID_ROOT`, which might be useful e.g. when storing persistent site data on network storage or separate partitions/disks.
+   * - VOLATILE_ROOT
+     - volatile
+     - Optionally use to point to another site tmp location than `volatile` subdir of `$DOCKER_MIGRID_ROOT`, which might be useful e.g. when storing logs on network storage or separate partitions/disks.
    * - UID
      - 1000
      - User ID of the migrid user inside the container, which might be useful to avoid various permission errors when juggling data inside and outside containers.

--- a/docker-compose_development.yml
+++ b/docker-compose_development.yml
@@ -120,6 +120,9 @@ services:
       - type: volume
         source: state
         target: /home/mig/state
+      - type: volume
+        source: migstate-log
+        target: /home/mig/state/log
       # NOTE: for read-only vgrids/workgroups we need a local 'ro' bind-mount
       - type: bind
         source: ${VGRID_FILES_WRITABLE}
@@ -177,6 +180,9 @@ services:
       - type: volume
         source: state
         target: /home/mig/state
+      - type: volume
+        source: migstate-log
+        target: /home/mig/state/log
       # NOTE: we don't need read-only vgrids/workgroups in the openid container
       # NOTE: mig_system_run is a shared volatile cache which gains from using host tmpfs
       - type: bind
@@ -220,6 +226,9 @@ services:
       - type: volume
         source: state
         target: /home/mig/state
+      - type: volume
+        source: migstate-log
+        target: /home/mig/state/log
       # NOTE: for read-only vgrids/workgroups we need a local 'ro' bind-mount
       - type: bind
         source: ${VGRID_FILES_WRITABLE}
@@ -267,6 +276,9 @@ services:
       - type: volume
         source: state
         target: /home/mig/state
+      - type: volume
+        source: migstate-log
+        target: /home/mig/state/log
       # NOTE: for read-only vgrids/workgroups we need a local 'ro' bind-mount
       - type: bind
         source: ${VGRID_FILES_WRITABLE}
@@ -313,6 +325,9 @@ services:
       - type: volume
         source: state
         target: /home/mig/state
+      - type: volume
+        source: migstate-log
+        target: /home/mig/state/log
       # NOTE: for read-only vgrids/workgroups we need a local 'ro' bind-mount
       - type: bind
         source: ${VGRID_FILES_WRITABLE}
@@ -390,13 +405,15 @@ volumes:
       type: none
       device: ${DOCKER_MIGRID_ROOT}/state
       o: bind
-  
+
+  # NOTE: we don't bother setting up persistent data outside state here
+
   migrid-syslog:
     # Volume used for exposing migrid container system log
     driver: local
     driver_opts:
       type: none
-      device: ${DOCKER_MIGRID_ROOT}/log/migrid
+      device: ${LOG_ROOT}/migrid
       o: bind
 
   migrid-openid-syslog:
@@ -404,7 +421,7 @@ volumes:
     driver: local
     driver_opts:
       type: none
-      device: ${DOCKER_MIGRID_ROOT}/log/migrid-openid
+      device: ${LOG_ROOT}/migrid-openid
       o: bind
 
   migrid-sftp-syslog:
@@ -412,7 +429,7 @@ volumes:
     driver: local
     driver_opts:
       type: none
-      device: ${DOCKER_MIGRID_ROOT}/log/migrid-sftp
+      device: ${LOG_ROOT}/migrid-sftp
       o: bind
 
   migrid-webdavs-syslog:
@@ -420,7 +437,7 @@ volumes:
     driver: local
     driver_opts:
       type: none
-      device: ${DOCKER_MIGRID_ROOT}/log/migrid-webdavs
+      device: ${LOG_ROOT}/migrid-webdavs
       o: bind
 
   migrid-ftps-syslog:
@@ -428,5 +445,13 @@ volumes:
     driver: local
     driver_opts:
       type: none
-      device: ${DOCKER_MIGRID_ROOT}/log/migrid-ftps
+      device: ${LOG_ROOT}/migrid-ftps
+      o: bind
+
+  migstate-log:
+    # Volume used to contain the migrid state log
+    driver: local
+    driver_opts:
+      type: none
+      device: ${LOG_ROOT}/migstatelog
       o: bind

--- a/docker-compose_development.yml
+++ b/docker-compose_development.yml
@@ -140,7 +140,7 @@ services:
     env_file:
       - migrid-httpd.env
     # IMPORTANT: please ONLY run with this test@ user for non-public hosts
-    command: /app/docker-entry.sh -V -u ${MIG_TEST_USER} -p ${MIG_TEST_USER_PASSWORD} -s "sftp ftps webdavs"
+    command: /app/docker-entry.sh -V -c -u ${MIG_TEST_USER} -p ${MIG_TEST_USER_PASSWORD} -s "sftp ftps webdavs"
     # NOTE: public hosts should create users through sign up and run like this
     #command: /app/docker-entry.sh -V
 

--- a/docker-compose_development_gdp.yml
+++ b/docker-compose_development_gdp.yml
@@ -63,7 +63,7 @@ services:
     env_file:
       - migrid-httpd.env
     # NOTE: public hosts should create users through sign up and run like this
-    command: /app/docker-entry.sh -V
+    command: /app/docker-entry.sh -V -c
 
   # The migrid core services including httpd and tightly integrated services
   # like job handling (grid script, monitor, sshmux, imnoty and vmproxy)

--- a/docker-compose_development_gdp.yml
+++ b/docker-compose_development_gdp.yml
@@ -120,6 +120,9 @@ services:
       - type: volume
         source: state
         target: /home/mig/state
+      - type: volume
+        source: migstate-log
+        target: /home/mig/state/log
       # NOTE: for read-only vgrids/workgroups we need a local 'ro' bind-mount
       - type: bind
         source: ${VGRID_FILES_WRITABLE}
@@ -181,6 +184,9 @@ services:
       - type: volume
         source: state
         target: /home/mig/state
+      - type: volume
+        source: migstate-log
+        target: /home/mig/state/log
       # NOTE: we don't need read-only vgrids/workgroups in the openid container
       # NOTE: mig_system_run is a shared volatile cache which gains from using host tmpfs
       - type: bind
@@ -224,6 +230,9 @@ services:
       - type: volume
         source: state
         target: /home/mig/state
+      - type: volume
+        source: migstate-log
+        target: /home/mig/state/log
       # NOTE: for read-only vgrids/workgroups we need a local 'ro' bind-mount
       - type: bind
         source: ${VGRID_FILES_WRITABLE}
@@ -271,6 +280,9 @@ services:
       - type: volume
         source: state
         target: /home/mig/state
+      - type: volume
+        source: migstate-log
+        target: /home/mig/state/log
       # NOTE: for read-only vgrids/workgroups we need a local 'ro' bind-mount
       - type: bind
         source: ${VGRID_FILES_WRITABLE}
@@ -317,6 +329,9 @@ services:
       - type: volume
         source: state
         target: /home/mig/state
+      - type: volume
+        source: migstate-log
+        target: /home/mig/state/log
       # NOTE: for read-only vgrids/workgroups we need a local 'ro' bind-mount
       - type: bind
         source: ${VGRID_FILES_WRITABLE}
@@ -397,12 +412,14 @@ volumes:
       device: ${DOCKER_MIGRID_ROOT}/state
       o: bind
   
+  # NOTE: we don't bother setting up persistent data outside state here
+
   migrid-syslog:
     # Volume used for exposing migrid container system log
     driver: local
     driver_opts:
       type: none
-      device: ${DOCKER_MIGRID_ROOT}/log/migrid
+      device: ${LOG_ROOT}/migrid
       o: bind
 
   migrid-openid-syslog:
@@ -410,7 +427,7 @@ volumes:
     driver: local
     driver_opts:
       type: none
-      device: ${DOCKER_MIGRID_ROOT}/log/migrid-openid
+      device: ${LOG_ROOT}/migrid-openid
       o: bind
 
   migrid-sftp-syslog:
@@ -418,7 +435,7 @@ volumes:
     driver: local
     driver_opts:
       type: none
-      device: ${DOCKER_MIGRID_ROOT}/log/migrid-sftp
+      device: ${LOG_ROOT}/migrid-sftp
       o: bind
 
   migrid-webdavs-syslog:
@@ -426,7 +443,7 @@ volumes:
     driver: local
     driver_opts:
       type: none
-      device: ${DOCKER_MIGRID_ROOT}/log/migrid-webdavs
+      device: ${LOG_ROOT}/migrid-webdavs
       o: bind
 
   migrid-ftps-syslog:
@@ -434,5 +451,13 @@ volumes:
     driver: local
     driver_opts:
       type: none
-      device: ${DOCKER_MIGRID_ROOT}/log/migrid-ftps
+      device: ${LOG_ROOT}/migrid-ftps
+      o: bind
+
+  migstate-log:
+    # Volume used to contain the migrid state log
+    driver: local
+    driver_opts:
+      type: none
+      device: ${LOG_ROOT}/migstatelog
       o: bind

--- a/docker-compose_production_bind.yml
+++ b/docker-compose_production_bind.yml
@@ -101,6 +101,43 @@ services:
       - type: volume
         source: state
         target: /home/mig/state
+      - type: volume
+        source: migrid-log
+        target: /home/mig/state/log
+      - type: volume
+        source: secrets
+        target: /home/mig/state/secrets
+      # NOTE: these wwwpublic helpers are only needed in apache
+      - type: volume
+        source: wwwpublic-archives
+        target: /home/mig/state/wwwpublic/archives
+      - type: volume
+        source: wwwpublic-vgrids
+        target: /home/mig/state/wwwpublic/vgrids
+      - type: volume
+        source: user_home
+        target: /home/mig/state/user_home
+      - type: volume
+        source: user_settings
+        target: /home/mig/state/user_settings
+      - type: volume
+        source: user_db_home
+        target: /home/mig/state/user_db_home
+      - type: volume
+        source: vgrid_home
+        target: /home/mig/state/vgrid_home
+      - type: volume
+        source: vgrid_private_base
+        target: /home/mig/state/vgrid_private_base
+      - type: volume
+        source: vgrid_public_base
+        target: /home/mig/state/vgrid_public_base
+      - type: volume
+        source: vgrid_files_home
+        target: /home/mig/state/vgrid_files_home
+      - type: volume
+        source: vgrid_files_writable
+        target: /home/mig/state/vgrid_files_writable
       # NOTE: for read-only vgrids/workgroups we need a local 'ro' bind-mount
       - type: bind
         source: ${VGRID_FILES_WRITABLE}
@@ -152,6 +189,43 @@ services:
       - type: volume
         source: state
         target: /home/mig/state
+      - type: volume
+        source: migrid-log
+        target: /home/mig/state/log
+      - type: volume
+        source: secrets
+        target: /home/mig/state/secrets
+      # NOTE: these wwwpublic helpers are only needed in apache
+      #- type: volume
+      #  source: wwwpublic-archives
+      #  target: /home/mig/state/wwwpublic/archives
+      #- type: volume
+      #  source: wwwpublic-vgrids
+      #  target: /home/mig/state/wwwpublic/vgrids
+      - type: volume
+        source: user_home
+        target: /home/mig/state/user_home
+      - type: volume
+        source: user_settings
+        target: /home/mig/state/user_settings
+      - type: volume
+        source: user_db_home
+        target: /home/mig/state/user_db_home
+      - type: volume
+        source: vgrid_home
+        target: /home/mig/state/vgrid_home
+      - type: volume
+        source: vgrid_private_base
+        target: /home/mig/state/vgrid_private_base
+      - type: volume
+        source: vgrid_public_base
+        target: /home/mig/state/vgrid_public_base
+      - type: volume
+        source: vgrid_files_home
+        target: /home/mig/state/vgrid_files_home
+      - type: volume
+        source: vgrid_files_writable
+        target: /home/mig/state/vgrid_files_writable
       # NOTE: we don't need read-only vgrids/workgroups in the openid container
       # NOTE: mig_system_run is a shared volatile cache which gains from using host tmpfs
       - type: bind
@@ -195,6 +269,43 @@ services:
       - type: volume
         source: state
         target: /home/mig/state
+      - type: volume
+        source: migrid-log
+        target: /home/mig/state/log
+      - type: volume
+        source: secrets
+        target: /home/mig/state/secrets
+      # NOTE: these wwwpublic helpers are only needed in apache
+      #- type: volume
+      #  source: wwwpublic-archives
+      #  target: /home/mig/state/wwwpublic/archives
+      #- type: volume
+      #  source: wwwpublic-vgrids
+      #  target: /home/mig/state/wwwpublic/vgrids
+      - type: volume
+        source: user_home
+        target: /home/mig/state/user_home
+      - type: volume
+        source: user_settings
+        target: /home/mig/state/user_settings
+      - type: volume
+        source: user_db_home
+        target: /home/mig/state/user_db_home
+      - type: volume
+        source: vgrid_home
+        target: /home/mig/state/vgrid_home
+      - type: volume
+        source: vgrid_private_base
+        target: /home/mig/state/vgrid_private_base
+      - type: volume
+        source: vgrid_public_base
+        target: /home/mig/state/vgrid_public_base
+      - type: volume
+        source: vgrid_files_home
+        target: /home/mig/state/vgrid_files_home
+      - type: volume
+        source: vgrid_files_writable
+        target: /home/mig/state/vgrid_files_writable
       # NOTE: for read-only vgrids/workgroups we need a local 'ro' bind-mount
       - type: bind
         source: ${VGRID_FILES_WRITABLE}
@@ -238,6 +349,43 @@ services:
       - type: volume
         source: state
         target: /home/mig/state
+      - type: volume
+        source: migrid-log
+        target: /home/mig/state/log
+      - type: volume
+        source: secrets
+        target: /home/mig/state/secrets
+      # NOTE: these wwwpublic helpers are only needed in apache
+      #- type: volume
+      #  source: wwwpublic-archives
+      #  target: /home/mig/state/wwwpublic/archives
+      #- type: volume
+      #  source: wwwpublic-vgrids
+      #  target: /home/mig/state/wwwpublic/vgrids
+      - type: volume
+        source: user_home
+        target: /home/mig/state/user_home
+      - type: volume
+        source: user_settings
+        target: /home/mig/state/user_settings
+      - type: volume
+        source: user_db_home
+        target: /home/mig/state/user_db_home
+      - type: volume
+        source: vgrid_home
+        target: /home/mig/state/vgrid_home
+      - type: volume
+        source: vgrid_private_base
+        target: /home/mig/state/vgrid_private_base
+      - type: volume
+        source: vgrid_public_base
+        target: /home/mig/state/vgrid_public_base
+      - type: volume
+        source: vgrid_files_home
+        target: /home/mig/state/vgrid_files_home
+      - type: volume
+        source: vgrid_files_writable
+        target: /home/mig/state/vgrid_files_writable
       # NOTE: for read-only vgrids/workgroups we need a local 'ro' bind-mount
       - type: bind
         source: ${VGRID_FILES_WRITABLE}
@@ -281,6 +429,43 @@ services:
       - type: volume
         source: state
         target: /home/mig/state
+      - type: volume
+        source: migrid-log
+        target: /home/mig/state/log
+      - type: volume
+        source: secrets
+        target: /home/mig/state/secrets
+      # NOTE: these wwwpublic helpers are only needed in apache
+      #- type: volume
+      #  source: wwwpublic-archives
+      #  target: /home/mig/state/wwwpublic/archives
+      #- type: volume
+      #  source: wwwpublic-vgrids
+      #  target: /home/mig/state/wwwpublic/vgrids
+      - type: volume
+        source: user_home
+        target: /home/mig/state/user_home
+      - type: volume
+        source: user_settings
+        target: /home/mig/state/user_settings
+      - type: volume
+        source: user_db_home
+        target: /home/mig/state/user_db_home
+      - type: volume
+        source: vgrid_home
+        target: /home/mig/state/vgrid_home
+      - type: volume
+        source: vgrid_private_base
+        target: /home/mig/state/vgrid_private_base
+      - type: volume
+        source: vgrid_public_base
+        target: /home/mig/state/vgrid_public_base
+      - type: volume
+        source: vgrid_files_home
+        target: /home/mig/state/vgrid_files_home
+      - type: volume
+        source: vgrid_files_writable
+        target: /home/mig/state/vgrid_files_writable
       # NOTE: for read-only vgrids/workgroups we need a local 'ro' bind-mount
       - type: bind
         source: ${VGRID_FILES_WRITABLE}
@@ -375,6 +560,94 @@ volumes:
       device: ${DOCKER_MIGRID_ROOT}/state
       o: bind
   
+  secrets:
+    # Volume used to contain the migrid secrets
+    driver: local
+    driver_opts:
+      type: none
+      device: ${DOCKER_MIGRID_ROOT}/persistent/secrets
+      o: bind
+
+  wwwpublic-archives:
+    # Volume used to contain the migrid wwwpublic/archives
+    driver: local
+    driver_opts:
+      type: none
+      device: ${DOCKER_MIGRID_ROOT}/persistent/wwwpublic-archives
+      o: bind
+
+  wwwpublic-vgrids:
+    # Volume used to contain the migrid wwwpublic/vgrids
+    driver: local
+    driver_opts:
+      type: none
+      device: ${DOCKER_MIGRID_ROOT}/persistent/wwwpublic-vgrids
+      o: bind
+
+  user_home:
+    # Volume used to contain the migrid user_home
+    driver: local
+    driver_opts:
+      type: none
+      device: ${DOCKER_MIGRID_ROOT}/persistent/user_home
+      o: bind
+
+  user_settings:
+    # Volume used to contain the migrid user_settings
+    driver: local
+    driver_opts:
+      type: none
+      device: ${DOCKER_MIGRID_ROOT}/persistent/user_settings
+      o: bind
+
+  user_db_home:
+    # Volume used to contain the migrid user_db_home
+    driver: local
+    driver_opts:
+      type: none
+      device: ${DOCKER_MIGRID_ROOT}/persistent/user_db_home
+      o: bind
+
+  vgrid_home:
+    # Volume used to contain the migrid vgrid_home
+    driver: local
+    driver_opts:
+      type: none
+      device: ${DOCKER_MIGRID_ROOT}/persistent/vgrid_home
+      o: bind
+
+  vgrid_private_base:
+    # Volume used to contain the migrid vgrid_private_base
+    driver: local
+    driver_opts:
+      type: none
+      device: ${DOCKER_MIGRID_ROOT}/persistent/vgrid_private_base
+      o: bind
+
+  vgrid_public_base:
+    # Volume used to contain the migrid vgrid_public_base
+    driver: local
+    driver_opts:
+      type: none
+      device: ${DOCKER_MIGRID_ROOT}/persistent/vgrid_public_base
+      o: bind
+
+  vgrid_files_home:
+    # Volume used to contain the migrid vgrid_files_home
+    driver: local
+    driver_opts:
+      type: none
+      device: ${DOCKER_MIGRID_ROOT}/persistent/vgrid_files_home
+      o: bind
+
+  vgrid_files_writable:
+    # Volume used to contain the migrid vgrid_files_writable
+    driver: local
+    driver_opts:
+      type: none
+      device: ${DOCKER_MIGRID_ROOT}/persistent/vgrid_files_writable
+      o: bind
+
   migrid-syslog:
     # Volume used for exposing migrid container system log
     driver: local
@@ -413,4 +686,12 @@ volumes:
     driver_opts:
       type: none
       device: ${DOCKER_MIGRID_ROOT}/log/migrid-ftps
+      o: bind
+
+  migrid-log:
+    # Volume used to contain the migrid state log
+    driver: local
+    driver_opts:
+      type: none
+      device: ${DOCKER_MIGRID_ROOT}/log/miglog
       o: bind

--- a/docker-compose_production_bind.yml
+++ b/docker-compose_production_bind.yml
@@ -102,7 +102,7 @@ services:
         source: state
         target: /home/mig/state
       - type: volume
-        source: migrid-log
+        source: migstate-log
         target: /home/mig/state/log
       - type: volume
         source: secrets
@@ -112,8 +112,43 @@ services:
         source: wwwpublic-archives
         target: /home/mig/state/wwwpublic/archives
       - type: volume
-        source: wwwpublic-vgrids
-        target: /home/mig/state/wwwpublic/vgrids
+        source: wwwpublic-vgrid
+        target: /home/mig/state/wwwpublic/vgrid
+      # NOTE: these next helpers are only needed in migrid container
+      - type: volume
+        source: freeze_home
+        target: /home/mig/state/freeze_home
+      - type: volume
+        source: mrsl_home
+        target: /home/mig/state/mrsl_home
+      - type: volume
+        source: resource_home
+        target: /home/mig/state/resource_home
+      - type: volume
+        source: re_home
+        target: /home/mig/state/re_home
+      - type: volume
+        source: sharelink_home
+        target: /home/mig/state/sharelink_home
+      - type: volume
+        source: events_home
+        target: /home/mig/state/events_home
+      - type: volume
+        source: sitestats_home
+        target: /home/mig/state/sitestats_home
+      - type: volume
+        source: sandbox_home
+        target: /home/mig/state/sandbox_home
+      - type: volume
+        source: sss_home
+        target: /home/mig/state/sss_home
+      - type: volume
+        source: workflows_db_home
+        target: /home/mig/state/workflows_db_home
+      - type: volume
+        source: workflows_home
+        target: /home/mig/state/workflows_home
+      # NOTE: general user and vgrid data required in almost all containers
       - type: volume
         source: user_home
         target: /home/mig/state/user_home
@@ -190,7 +225,7 @@ services:
         source: state
         target: /home/mig/state
       - type: volume
-        source: migrid-log
+        source: migstate-log
         target: /home/mig/state/log
       - type: volume
         source: secrets
@@ -200,8 +235,43 @@ services:
       #  source: wwwpublic-archives
       #  target: /home/mig/state/wwwpublic/archives
       #- type: volume
-      #  source: wwwpublic-vgrids
-      #  target: /home/mig/state/wwwpublic/vgrids
+      #  source: wwwpublic-vgrid
+      #  target: /home/mig/state/wwwpublic/vgrid
+      # NOTE: these next helpers are only needed in migrid container
+      #- type: volume
+      #  source: freeze_home
+      #  target: /home/mig/state/freeze_home
+      #- type: volume
+      #  source: mrsl_home
+      #  target: /home/mig/state/mrsl_home
+      #- type: volume
+      #  source: resource_home
+      #  target: /home/mig/state/resource_home
+      #- type: volume
+      #  source: re_home
+      #  target: /home/mig/state/re_home
+      #- type: volume
+      #  source: sharelink_home
+      #  target: /home/mig/state/sharelink_home
+      #- type: volume
+      #  source: events_home
+      #  target: /home/mig/state/events_home
+      #- type: volume
+      #  source: sitestats_home
+      #  target: /home/mig/state/sitestats_home
+      #- type: volume
+      #  source: sandbox_home
+      #  target: /home/mig/state/sandbox_home
+      #- type: volume
+      #  source: sss_home
+      #  target: /home/mig/state/sss_home
+      #- type: volume
+      #  source: workflows_db_home
+      #  target: /home/mig/state/workflows_db_home
+      #- type: volume
+      #  source: workflows_home
+      #  target: /home/mig/state/workflows_home
+      # NOTE: general user and vgrid data required in almost all containers
       - type: volume
         source: user_home
         target: /home/mig/state/user_home
@@ -270,7 +340,7 @@ services:
         source: state
         target: /home/mig/state
       - type: volume
-        source: migrid-log
+        source: migstate-log
         target: /home/mig/state/log
       - type: volume
         source: secrets
@@ -280,8 +350,50 @@ services:
       #  source: wwwpublic-archives
       #  target: /home/mig/state/wwwpublic/archives
       #- type: volume
-      #  source: wwwpublic-vgrids
-      #  target: /home/mig/state/wwwpublic/vgrids
+      #  source: wwwpublic-vgrid
+      #  target: /home/mig/state/wwwpublic/vgrid
+      # NOTE: these wwwpublic helpers are only needed in apache
+      #- type: volume
+      #  source: wwwpublic-archives
+      #  target: /home/mig/state/wwwpublic/archives
+      #- type: volume
+      #  source: wwwpublic-vgrid
+      #  target: /home/mig/state/wwwpublic/vgrid
+      # NOTE: these next helpers are only needed in migrid container
+      #- type: volume
+      #  source: freeze_home
+      #  target: /home/mig/state/freeze_home
+      #- type: volume
+      #  source: mrsl_home
+      #  target: /home/mig/state/mrsl_home
+      #- type: volume
+      #  source: resource_home
+      #  target: /home/mig/state/resource_home
+      #- type: volume
+      #  source: re_home
+      #  target: /home/mig/state/re_home
+      #- type: volume
+      #  source: sharelink_home
+      #  target: /home/mig/state/sharelink_home
+      #- type: volume
+      #  source: events_home
+      #  target: /home/mig/state/events_home
+      #- type: volume
+      #  source: sitestats_home
+      #  target: /home/mig/state/sitestats_home
+      #- type: volume
+      #  source: sandbox_home
+      #  target: /home/mig/state/sandbox_home
+      #- type: volume
+      #  source: sss_home
+      #  target: /home/mig/state/sss_home
+      #- type: volume
+      #  source: workflows_db_home
+      #  target: /home/mig/state/workflows_db_home
+      #- type: volume
+      #  source: workflows_home
+      #  target: /home/mig/state/workflows_home
+      # NOTE: general user and vgrid data required in almost all containers
       - type: volume
         source: user_home
         target: /home/mig/state/user_home
@@ -350,7 +462,7 @@ services:
         source: state
         target: /home/mig/state
       - type: volume
-        source: migrid-log
+        source: migstate-log
         target: /home/mig/state/log
       - type: volume
         source: secrets
@@ -360,8 +472,50 @@ services:
       #  source: wwwpublic-archives
       #  target: /home/mig/state/wwwpublic/archives
       #- type: volume
-      #  source: wwwpublic-vgrids
-      #  target: /home/mig/state/wwwpublic/vgrids
+      #  source: wwwpublic-vgrid
+      #  target: /home/mig/state/wwwpublic/vgrid
+      # NOTE: these wwwpublic helpers are only needed in apache
+      #- type: volume
+      #  source: wwwpublic-archives
+      #  target: /home/mig/state/wwwpublic/archives
+      #- type: volume
+      #  source: wwwpublic-vgrid
+      #  target: /home/mig/state/wwwpublic/vgrid
+      # NOTE: these next helpers are only needed in migrid container
+      #- type: volume
+      #  source: freeze_home
+      #  target: /home/mig/state/freeze_home
+      #- type: volume
+      #  source: mrsl_home
+      #  target: /home/mig/state/mrsl_home
+      #- type: volume
+      #  source: resource_home
+      #  target: /home/mig/state/resource_home
+      #- type: volume
+      #  source: re_home
+      #  target: /home/mig/state/re_home
+      #- type: volume
+      #  source: sharelink_home
+      #  target: /home/mig/state/sharelink_home
+      #- type: volume
+      #  source: events_home
+      #  target: /home/mig/state/events_home
+      #- type: volume
+      #  source: sitestats_home
+      #  target: /home/mig/state/sitestats_home
+      #- type: volume
+      #  source: sandbox_home
+      #  target: /home/mig/state/sandbox_home
+      #- type: volume
+      #  source: sss_home
+      #  target: /home/mig/state/sss_home
+      #- type: volume
+      #  source: workflows_db_home
+      #  target: /home/mig/state/workflows_db_home
+      #- type: volume
+      #  source: workflows_home
+      #  target: /home/mig/state/workflows_home
+      # NOTE: general user and vgrid data required in almost all containers
       - type: volume
         source: user_home
         target: /home/mig/state/user_home
@@ -430,7 +584,7 @@ services:
         source: state
         target: /home/mig/state
       - type: volume
-        source: migrid-log
+        source: migstate-log
         target: /home/mig/state/log
       - type: volume
         source: secrets
@@ -440,8 +594,50 @@ services:
       #  source: wwwpublic-archives
       #  target: /home/mig/state/wwwpublic/archives
       #- type: volume
-      #  source: wwwpublic-vgrids
-      #  target: /home/mig/state/wwwpublic/vgrids
+      #  source: wwwpublic-vgrid
+      #  target: /home/mig/state/wwwpublic/vgrid
+      # NOTE: these wwwpublic helpers are only needed in apache
+      #- type: volume
+      #  source: wwwpublic-archives
+      #  target: /home/mig/state/wwwpublic/archives
+      #- type: volume
+      #  source: wwwpublic-vgrid
+      #  target: /home/mig/state/wwwpublic/vgrid
+      # NOTE: these next helpers are only needed in migrid container
+      #- type: volume
+      #  source: freeze_home
+      #  target: /home/mig/state/freeze_home
+      #- type: volume
+      #  source: mrsl_home
+      #  target: /home/mig/state/mrsl_home
+      #- type: volume
+      #  source: resource_home
+      #  target: /home/mig/state/resource_home
+      #- type: volume
+      #  source: re_home
+      #  target: /home/mig/state/re_home
+      #- type: volume
+      #  source: sharelink_home
+      #  target: /home/mig/state/sharelink_home
+      #- type: volume
+      #  source: events_home
+      #  target: /home/mig/state/events_home
+      #- type: volume
+      #  source: sitestats_home
+      #  target: /home/mig/state/sitestats_home
+      #- type: volume
+      #  source: sandbox_home
+      #  target: /home/mig/state/sandbox_home
+      #- type: volume
+      #  source: sss_home
+      #  target: /home/mig/state/sss_home
+      #- type: volume
+      #  source: workflows_db_home
+      #  target: /home/mig/state/workflows_db_home
+      #- type: volume
+      #  source: workflows_home
+      #  target: /home/mig/state/workflows_home
+      # NOTE: general user and vgrid data required in almost all containers
       - type: volume
         source: user_home
         target: /home/mig/state/user_home
@@ -565,7 +761,7 @@ volumes:
     driver: local
     driver_opts:
       type: none
-      device: ${DOCKER_MIGRID_ROOT}/persistent/secrets
+      device: ${PERSISTENT_ROOT}/secrets
       o: bind
 
   wwwpublic-archives:
@@ -573,15 +769,103 @@ volumes:
     driver: local
     driver_opts:
       type: none
-      device: ${DOCKER_MIGRID_ROOT}/persistent/wwwpublic-archives
+      device: ${PERSISTENT_ROOT}/wwwpublic-archives
       o: bind
 
-  wwwpublic-vgrids:
-    # Volume used to contain the migrid wwwpublic/vgrids
+  wwwpublic-vgrid:
+    # Volume used to contain the migrid wwwpublic/vgrid
     driver: local
     driver_opts:
       type: none
-      device: ${DOCKER_MIGRID_ROOT}/persistent/wwwpublic-vgrids
+      device: ${PERSISTENT_ROOT}/wwwpublic-vgrid
+      o: bind
+
+  wwwpublic-download:
+    # Volume used to contain the migrid wwwpublic/download
+    driver: local
+    driver_opts:
+      type: none
+      device: ${PERSISTENT_ROOT}/wwwpublic-download
+      o: bind
+
+  freeze_home:
+    # Volume used to contain the migrid freeze_home
+    driver: local
+    driver_opts:
+      type: none
+      device: ${PERSISTENT_ROOT}/freeze_home
+      o: bind
+
+  mrsl_home:
+    # Volume used to contain the migrid mrsl_home
+    driver: local
+    driver_opts:
+      type: none
+      device: ${PERSISTENT_ROOT}/mrsl_home
+      o: bind
+
+  resource_home:
+    # Volume used to contain the migrid resource_home
+    driver: local
+    driver_opts:
+      type: none
+      device: ${PERSISTENT_ROOT}/resource_home
+      o: bind
+
+  re_home:
+    # Volume used to contain the migrid re_home
+    driver: local
+    driver_opts:
+      type: none
+      device: ${PERSISTENT_ROOT}/re_home
+      o: bind
+
+  events_home:
+    # Volume used to contain the migrid events_home
+    driver: local
+    driver_opts:
+      type: none
+      device: ${PERSISTENT_ROOT}/events_home
+      o: bind
+
+  sitestats_home:
+    # Volume used to contain the migrid sitestats_home
+    driver: local
+    driver_opts:
+      type: none
+      device: ${PERSISTENT_ROOT}/sitestats_home
+      o: bind
+
+  sandbox_home:
+    # Volume used to contain the migrid sandbox_home
+    driver: local
+    driver_opts:
+      type: none
+      device: ${PERSISTENT_ROOT}/sandbox_home
+      o: bind
+
+  sss_home:
+    # Volume used to contain the migrid sss_home
+    driver: local
+    driver_opts:
+      type: none
+      device: ${PERSISTENT_ROOT}/sss_home
+      o: bind
+
+  workflows_db_home:
+    # Volume used to contain the migrid workflows_db_home
+    driver: local
+    driver_opts:
+      type: none
+      device: ${PERSISTENT_ROOT}/workflows_db_home
+      o: bind
+
+  workflows_home:
+    # Volume used to contain the migrid workflows_home
+    driver: local
+    driver_opts:
+      type: none
+      device: ${PERSISTENT_ROOT}/workflows_home
       o: bind
 
   user_home:
@@ -589,7 +873,7 @@ volumes:
     driver: local
     driver_opts:
       type: none
-      device: ${DOCKER_MIGRID_ROOT}/persistent/user_home
+      device: ${PERSISTENT_ROOT}/user_home
       o: bind
 
   user_settings:
@@ -597,7 +881,7 @@ volumes:
     driver: local
     driver_opts:
       type: none
-      device: ${DOCKER_MIGRID_ROOT}/persistent/user_settings
+      device: ${PERSISTENT_ROOT}/user_settings
       o: bind
 
   user_db_home:
@@ -605,7 +889,7 @@ volumes:
     driver: local
     driver_opts:
       type: none
-      device: ${DOCKER_MIGRID_ROOT}/persistent/user_db_home
+      device: ${PERSISTENT_ROOT}/user_db_home
       o: bind
 
   vgrid_home:
@@ -613,7 +897,7 @@ volumes:
     driver: local
     driver_opts:
       type: none
-      device: ${DOCKER_MIGRID_ROOT}/persistent/vgrid_home
+      device: ${PERSISTENT_ROOT}/vgrid_home
       o: bind
 
   vgrid_private_base:
@@ -621,7 +905,7 @@ volumes:
     driver: local
     driver_opts:
       type: none
-      device: ${DOCKER_MIGRID_ROOT}/persistent/vgrid_private_base
+      device: ${PERSISTENT_ROOT}/vgrid_private_base
       o: bind
 
   vgrid_public_base:
@@ -629,7 +913,7 @@ volumes:
     driver: local
     driver_opts:
       type: none
-      device: ${DOCKER_MIGRID_ROOT}/persistent/vgrid_public_base
+      device: ${PERSISTENT_ROOT}/vgrid_public_base
       o: bind
 
   vgrid_files_home:
@@ -637,7 +921,7 @@ volumes:
     driver: local
     driver_opts:
       type: none
-      device: ${DOCKER_MIGRID_ROOT}/persistent/vgrid_files_home
+      device: ${PERSISTENT_ROOT}/vgrid_files_home
       o: bind
 
   vgrid_files_writable:
@@ -645,7 +929,7 @@ volumes:
     driver: local
     driver_opts:
       type: none
-      device: ${DOCKER_MIGRID_ROOT}/persistent/vgrid_files_writable
+      device: ${PERSISTENT_ROOT}/vgrid_files_writable
       o: bind
 
   migrid-syslog:
@@ -653,7 +937,7 @@ volumes:
     driver: local
     driver_opts:
       type: none
-      device: ${DOCKER_MIGRID_ROOT}/log/migrid
+      device: ${LOG_ROOT}/migrid
       o: bind
 
   migrid-openid-syslog:
@@ -661,7 +945,7 @@ volumes:
     driver: local
     driver_opts:
       type: none
-      device: ${DOCKER_MIGRID_ROOT}/log/migrid-openid
+      device: ${LOG_ROOT}/migrid-openid
       o: bind
 
   migrid-sftp-syslog:
@@ -669,7 +953,7 @@ volumes:
     driver: local
     driver_opts:
       type: none
-      device: ${DOCKER_MIGRID_ROOT}/log/migrid-sftp
+      device: ${LOG_ROOT}/migrid-sftp
       o: bind
 
   migrid-webdavs-syslog:
@@ -677,7 +961,7 @@ volumes:
     driver: local
     driver_opts:
       type: none
-      device: ${DOCKER_MIGRID_ROOT}/log/migrid-webdavs
+      device: ${LOG_ROOT}/migrid-webdavs
       o: bind
 
   migrid-ftps-syslog:
@@ -685,13 +969,13 @@ volumes:
     driver: local
     driver_opts:
       type: none
-      device: ${DOCKER_MIGRID_ROOT}/log/migrid-ftps
+      device: ${LOG_ROOT}/migrid-ftps
       o: bind
 
-  migrid-log:
+  migstate-log:
     # Volume used to contain the migrid state log
     driver: local
     driver_opts:
       type: none
-      device: ${DOCKER_MIGRID_ROOT}/log/miglog
+      device: ${LOG_ROOT}/migstatelog
       o: bind

--- a/docker-compose_production_bind.yml
+++ b/docker-compose_production_bind.yml
@@ -119,8 +119,8 @@ services:
         source: freeze_home
         target: /home/mig/state/freeze_home
       - type: volume
-        source: mrsl_home
-        target: /home/mig/state/mrsl_home
+        source: mrsl_files
+        target: /home/mig/state/mrsl_files
       - type: volume
         source: resource_home
         target: /home/mig/state/resource_home
@@ -242,8 +242,8 @@ services:
       #  source: freeze_home
       #  target: /home/mig/state/freeze_home
       #- type: volume
-      #  source: mrsl_home
-      #  target: /home/mig/state/mrsl_home
+      #  source: mrsl_files
+      #  target: /home/mig/state/mrsl_files
       #- type: volume
       #  source: resource_home
       #  target: /home/mig/state/resource_home
@@ -364,8 +364,8 @@ services:
       #  source: freeze_home
       #  target: /home/mig/state/freeze_home
       #- type: volume
-      #  source: mrsl_home
-      #  target: /home/mig/state/mrsl_home
+      #  source: mrsl_files
+      #  target: /home/mig/state/mrsl_files
       #- type: volume
       #  source: resource_home
       #  target: /home/mig/state/resource_home
@@ -486,8 +486,8 @@ services:
       #  source: freeze_home
       #  target: /home/mig/state/freeze_home
       #- type: volume
-      #  source: mrsl_home
-      #  target: /home/mig/state/mrsl_home
+      #  source: mrsl_files
+      #  target: /home/mig/state/mrsl_files
       #- type: volume
       #  source: resource_home
       #  target: /home/mig/state/resource_home
@@ -608,8 +608,8 @@ services:
       #  source: freeze_home
       #  target: /home/mig/state/freeze_home
       #- type: volume
-      #  source: mrsl_home
-      #  target: /home/mig/state/mrsl_home
+      #  source: mrsl_files
+      #  target: /home/mig/state/mrsl_files
       #- type: volume
       #  source: resource_home
       #  target: /home/mig/state/resource_home
@@ -796,12 +796,12 @@ volumes:
       device: ${PERSISTENT_ROOT}/freeze_home
       o: bind
 
-  mrsl_home:
-    # Volume used to contain the migrid mrsl_home
+  mrsl_files:
+    # Volume used to contain the migrid mrsl_files
     driver: local
     driver_opts:
       type: none
-      device: ${PERSISTENT_ROOT}/mrsl_home
+      device: ${PERSISTENT_ROOT}/mrsl_files
       o: bind
 
   resource_home:
@@ -818,6 +818,14 @@ volumes:
     driver_opts:
       type: none
       device: ${PERSISTENT_ROOT}/re_home
+      o: bind
+
+  sharelink_home:
+    # Volume used to contain the migrid sharelink_home
+    driver: local
+    driver_opts:
+      type: none
+      device: ${PERSISTENT_ROOT}/sharelink_home
       o: bind
 
   events_home:

--- a/docker-compose_production_bind.yml
+++ b/docker-compose_production_bind.yml
@@ -53,7 +53,7 @@ services:
     env_file:
       - migrid-httpd.env
     # NOTE: public hosts should create users through sign up and run like this
-    command: /app/docker-entry.sh -V
+    command: /app/docker-entry.sh -V -c
 
   # The migrid core services including httpd and tightly integrated services
   # like job handling (grid script, monitor, sshmux, imnoty and vmproxy)

--- a/docker-entry.sh
+++ b/docker-entry.sh
@@ -4,6 +4,7 @@
 # specified in the provided RUN_SERVICES environment.
 # Continuously checks whether the selected services are still alive.
 
+CHECKCONF=0
 KEEPALIVE=0
 VERSIONINFO=0
 

--- a/production.env
+++ b/production.env
@@ -185,7 +185,7 @@ EXTRA_USERPAGE_STYLES=""
 # sudo mount /storage/tmpfs/mig_system_run
 # NOTE: toggle commenting on  next two lines if you have such a tmpfs set up in the given path
 #MIG_SYSTEM_RUN=/storage/tmpfs/mig_system_run
-MIG_SYSTEM_RUN=${DOCKER_MIGRID_ROOT}/state/mig_system_run
+MIG_SYSTEM_RUN=${DOCKER_MIGRID_ROOT}/volatile/mig_system_run
 # The apache auth openid module performs and scales better if the associated
 # internal openid store directory runs from fast storage. It's a volatile data
 # store, which allows more concurrent OpenID 2.0 clients if it e.g. uses tmpfs.
@@ -194,9 +194,14 @@ MIG_SYSTEM_RUN=${DOCKER_MIGRID_ROOT}/state/mig_system_run
 # Otherwise you can safely ignore the OPENID_STORE setting.
 # NOTE: toggle commenting on next two lines if you have such a tmpfs set up in the given path
 #OPENID_STORE=/storage/tmpfs/openid_store
-OPENID_STORE=${DOCKER_MIGRID_ROOT}/state/openid_store
+OPENID_STORE=${DOCKER_MIGRID_ROOT}/volatile/openid_store
 # We need a read-only bind mounted version of the vgrid_files_writable
 # directory and the underlying location can be configured here.
+# If you mount your user data storage on a different location say outside the
+# docker-migrid root you'd want to adjust the value here to also point into
+# that location.
+# NOTE: toggle commenting on next two lines if you have a netfs mount set up in the given path
+#VGRID_FILES_WRITABLE=/storage/netfs/vgrid_files_writable
 VGRID_FILES_WRITABLE=${DOCKER_MIGRID_ROOT}/state/vgrid_files_writable
 
 # Which svn repo and version of migrid should be used

--- a/production.env
+++ b/production.env
@@ -202,7 +202,7 @@ OPENID_STORE=${DOCKER_MIGRID_ROOT}/volatile/openid_store
 # that location.
 # NOTE: toggle commenting on next two lines if you have a netfs mount set up in the given path
 #VGRID_FILES_WRITABLE=/storage/netfs/vgrid_files_writable
-VGRID_FILES_WRITABLE=${DOCKER_MIGRID_ROOT}/state/vgrid_files_writable
+VGRID_FILES_WRITABLE=${DOCKER_MIGRID_ROOT}/persistent/vgrid_files_writable
 
 # Which svn repo and version of migrid should be used
 #MIG_SVN_REPO=https://svn.code.sf.net/p/migrid/code/trunk

--- a/production.env
+++ b/production.env
@@ -12,6 +12,13 @@ CONTAINER_REGISTRY=${CONTAINER_REGISTRY:-docker.io}
 # IMPORTANT: with docker on centos7 RO-mounts may fail unless we use an abs path
 DOCKER_MIGRID_ROOT=.
 
+# Helper storage locations as subdirs in DOCKER_MIGRID_ROOT by default
+# On real production sites you probably want to store them elsewhere on
+# scalable storage.
+LOG_ROOT=${DOCKER_MIGRID_ROOT}/sitelogs
+PERSISTENT_ROOT=${DOCKER_MIGRID_ROOT}/sitedata
+VOLATILE_ROOT=${DOCKER_MIGRID_ROOT}/sitetmp
+
 # Set to override container user and group IDs
 #UID=1000
 #GID=1000
@@ -185,7 +192,7 @@ EXTRA_USERPAGE_STYLES=""
 # sudo mount /storage/tmpfs/mig_system_run
 # NOTE: toggle commenting on  next two lines if you have such a tmpfs set up in the given path
 #MIG_SYSTEM_RUN=/storage/tmpfs/mig_system_run
-MIG_SYSTEM_RUN=${DOCKER_MIGRID_ROOT}/volatile/mig_system_run
+MIG_SYSTEM_RUN=${VOLATILE_ROOT}/mig_system_run
 # The apache auth openid module performs and scales better if the associated
 # internal openid store directory runs from fast storage. It's a volatile data
 # store, which allows more concurrent OpenID 2.0 clients if it e.g. uses tmpfs.
@@ -194,7 +201,7 @@ MIG_SYSTEM_RUN=${DOCKER_MIGRID_ROOT}/volatile/mig_system_run
 # Otherwise you can safely ignore the OPENID_STORE setting.
 # NOTE: toggle commenting on next two lines if you have such a tmpfs set up in the given path
 #OPENID_STORE=/storage/tmpfs/openid_store
-OPENID_STORE=${DOCKER_MIGRID_ROOT}/volatile/openid_store
+OPENID_STORE=${VOLATILE_ROOT}/openid_store
 # We need a read-only bind mounted version of the vgrid_files_writable
 # directory and the underlying location can be configured here.
 # If you mount your user data storage on a different location say outside the
@@ -202,7 +209,7 @@ OPENID_STORE=${DOCKER_MIGRID_ROOT}/volatile/openid_store
 # that location.
 # NOTE: toggle commenting on next two lines if you have a netfs mount set up in the given path
 #VGRID_FILES_WRITABLE=/storage/netfs/vgrid_files_writable
-VGRID_FILES_WRITABLE=${DOCKER_MIGRID_ROOT}/persistent/vgrid_files_writable
+VGRID_FILES_WRITABLE=${PERSISTENT_ROOT}/vgrid_files_writable
 
 # Which svn repo and version of migrid should be used
 #MIG_SVN_REPO=https://svn.code.sf.net/p/migrid/code/trunk


### PR DESCRIPTION
 Introduce new persistent and volatile helper dirs for holding the data and over mounted onto 'state' in containers. Use them for the over mount variables in `production.env` and assign them as volumes in the corresponding docker-compose file. That should address the issues reported by AU about the 'state' dir not being properly populated with the migrid built-in state subdirs when the production example or variations thereof is used and containers are brought up from scratch.
Please note that the changes only affect the production_bind version of docker-compose as we still want to eliminate the non-bind version with PR55.