### PR TITLE
Adjust containers for OS mail delivery through SMPT_SERVER if set

### DIFF
--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -435,8 +435,7 @@ RUN if [ "${WITH_PY3}" = True ]; then \
 RUN if [ -n "${SMTP_SERVER}" ]; then \
       echo "# Simple SMTP setup to route all local mail to host SMTP" > /etc/esmtprc && \
       echo "hostname ${SMTP_SERVER}:25" >> /etc/esmtprc && \
-      echo "qualifydomain ${DOMAIN}" >> /etc/esmtprc && \
-      echo "root: ${ADMIN_EMAIL}" >> /etc/aliases ; \
+      echo "qualifydomain ${DOMAIN}" >> /etc/esmtprc ; \
     fi
 
 # TODO: this breaks yum etc in build - can we switch default?

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -303,6 +303,8 @@ ARG WITH_PY3
 ARG PREFER_PYTHON3
 ARG UID
 ARG GID
+ARG SMTP_SERVER
+ARG ADMIN_EMAIL
 
 # Make sure pip has a valid cert chain to avoid cert errors on pypi repo, etc.
 # https://stackoverflow.com/questions/25981703/pip-install-fails-with-connection-error-ssl-certificate-verify-failed-certi
@@ -382,6 +384,7 @@ RUN yum update -y \
     ipset \
     wget \
     patch \
+    esmtp \
     # NOTE: only install default paramiko if upgrade not requested
     && [ "${UPGRADE_PARAMIKO}" = "True" ] || yum install -y python-paramiko \
     # NOTE: no default openstack client for python2 here
@@ -425,6 +428,16 @@ RUN if [ "${WITH_PY3}" = True ]; then \
     else \
       echo "no py3 deps"; \
     fi;
+
+# Containers have esmtp installed by default but we explicitly include it above
+# and configure it for host SMTP delivery for cronjobs etc to be able to route
+# mail outside containers.
+RUN if [ -n "${SMTP_SERVER}" ]; then \
+      echo "# Simple SMTP setup to route all local mail to host SMTP" > /etc/esmtprc && \
+      echo "hostname ${SMTP_SERVER}:25" >> /etc/esmtprc && \
+      echo "qualifydomain ${DOMAIN}" >> /etc/esmtprc && \
+      echo "root: ${ADMIN_EMAIL}" >> /etc/aliases ; \
+    fi
 
 # TODO: this breaks yum etc in build - can we switch default?
 #RUN if [ "${PREFER_PYTHON3}" = "True" ]; then \

--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -308,6 +308,8 @@ ARG WITH_PY3
 ARG PREFER_PYTHON3
 ARG UID
 ARG GID
+ARG SMTP_SERVER
+ARG ADMIN_EMAIL
 
 WORKDIR /tmp
 
@@ -386,6 +388,7 @@ RUN dnf update -y \
     ipset \
     wget \
     patch \
+    esmtp \
     # NOTE: no default paramiko for python2 here
     #&& [ "${UPGRADE_PARAMIKO}" = True ] || dnf install -y python-paramiko \
     # NOTE: no default openstack client for python2 here
@@ -428,6 +431,16 @@ RUN if [ "${WITH_PY3}" = "True" ]; then \
     else \
       echo "no py3 deps"; \
     fi;
+
+# Containers have esmtp installed by default but we explicitly include it above
+# and configure it for host SMTP delivery for cronjobs etc to be able to route
+# mail outside containers.
+RUN if [ -n "${SMTP_SERVER}" ]; then \
+      echo "# Simple SMTP setup to route all local mail to host SMTP" > /etc/esmtprc && \
+      echo "hostname ${SMTP_SERVER}:25" >> /etc/esmtprc && \
+      echo "qualifydomain ${DOMAIN}" >> /etc/esmtprc && \
+      echo "root: ${ADMIN_EMAIL}" >> /etc/aliases ; \
+    fi
 
 RUN if [ "${PREFER_PYTHON3}" = "True" ]; then \
       echo "set up py3 as default python" && \

--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -438,8 +438,7 @@ RUN if [ "${WITH_PY3}" = "True" ]; then \
 RUN if [ -n "${SMTP_SERVER}" ]; then \
       echo "# Simple SMTP setup to route all local mail to host SMTP" > /etc/esmtprc && \
       echo "hostname ${SMTP_SERVER}:25" >> /etc/esmtprc && \
-      echo "qualifydomain ${DOMAIN}" >> /etc/esmtprc && \
-      echo "root: ${ADMIN_EMAIL}" >> /etc/aliases ; \
+      echo "qualifydomain ${DOMAIN}" >> /etc/esmtprc ; \
     fi
 
 RUN if [ "${PREFER_PYTHON3}" = "True" ]; then \

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -307,6 +307,8 @@ ARG WITH_PY3
 ARG PREFER_PYTHON3
 ARG UID
 ARG GID
+ARG SMTP_SERVER
+ARG ADMIN_EMAIL
 ARG ENABLE_OPENID
 
 WORKDIR /tmp
@@ -370,6 +372,7 @@ RUN dnf update -y \
     ipset \
     wget \
     patch \
+    esmtp \
     && dnf clean all \
     && rm -fr /var/cache/dnf
 
@@ -410,6 +413,16 @@ RUN if [ "${WITH_PY3}" = "True" ]; then \
     else \
       echo "no py3 deps"; \
     fi;
+
+# Containers have esmtp installed by default but we explicitly include it above
+# and configure it for host SMTP delivery for cronjobs etc to be able to route
+# mail outside containers.
+RUN if [ -n "${SMTP_SERVER}" ]; then \
+      echo "# Simple SMTP setup to route all local mail to host SMTP" > /etc/esmtprc && \
+      echo "hostname ${SMTP_SERVER}:25" >> /etc/esmtprc && \
+      echo "qualifydomain ${DOMAIN}" >> /etc/esmtprc && \
+      echo "root: ${ADMIN_EMAIL}" >> /etc/aliases ; \
+    fi
 
 RUN if [ "${PREFER_PYTHON3}" = "True" ]; then \
       echo "set up py3 as default python" && \

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -420,8 +420,7 @@ RUN if [ "${WITH_PY3}" = "True" ]; then \
 RUN if [ -n "${SMTP_SERVER}" ]; then \
       echo "# Simple SMTP setup to route all local mail to host SMTP" > /etc/esmtprc && \
       echo "hostname ${SMTP_SERVER}:25" >> /etc/esmtprc && \
-      echo "qualifydomain ${DOMAIN}" >> /etc/esmtprc && \
-      echo "root: ${ADMIN_EMAIL}" >> /etc/aliases ; \
+      echo "qualifydomain ${DOMAIN}" >> /etc/esmtprc ; \
     fi
 
 RUN if [ "${PREFER_PYTHON3}" = "True" ]; then \


### PR DESCRIPTION
Explicitly require `esmtp` as the default SMTP in containers (already default) and configure it to deliver mail through an SMTP running at the host or whatever `SMTP_SERVER` specifies. This is helpful e.g. for passing output of cronjobs in the containers to admins.
The SMTP configuration is skipped if `SMTP_SERVER` is left empty and left to the default delivery to a rather well-hidden  mail spool file in the containers.

