### PR TITLE
Apache init helper

### DIFF
--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -1509,6 +1509,7 @@ RUN if [ "${ENABLE_LOGROTATE}" = "True" ]; then \
 
 # Init scripts
 RUN cp generated-confs/migrid-init.d-rh /etc/init.d/migrid
+COPY apache-init-helper /etc/init.d/apache-minimal
 
 WORKDIR $MIG_ROOT
 

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -1509,6 +1509,7 @@ RUN if [ "${ENABLE_LOGROTATE}" = "True" ]; then \
 
 # Init scripts
 RUN cp generated-confs/migrid-init.d-rh /etc/init.d/migrid
+COPY migrid-httpd-init.sh /etc/sysconfig/apache-minimal
 COPY apache-init-helper /etc/init.d/apache-minimal
 
 WORKDIR $MIG_ROOT

--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -1535,6 +1535,7 @@ RUN if [ "${ENABLE_LOGROTATE}" = "True" ]; then \
 
 # Init scripts
 RUN cp generated-confs/migrid-init.d-rh /etc/init.d/migrid
+COPY apache-init-helper /etc/init.d/apache-minimal
 
 WORKDIR $MIG_ROOT
 

--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -1535,6 +1535,7 @@ RUN if [ "${ENABLE_LOGROTATE}" = "True" ]; then \
 
 # Init scripts
 RUN cp generated-confs/migrid-init.d-rh /etc/init.d/migrid
+COPY migrid-httpd-init.sh /etc/sysconfig/apache-minimal
 COPY apache-init-helper /etc/init.d/apache-minimal
 
 WORKDIR $MIG_ROOT

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -1411,6 +1411,7 @@ RUN if [ "${ENABLE_LOGROTATE}" = "True" ]; then \
 
 # Init scripts
 RUN cp generated-confs/migrid-init.d-rh /etc/init.d/migrid
+COPY apache-init-helper /etc/init.d/apache-minimal
 
 WORKDIR $MIG_ROOT
 

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -1411,6 +1411,7 @@ RUN if [ "${ENABLE_LOGROTATE}" = "True" ]; then \
 
 # Init scripts
 RUN cp generated-confs/migrid-init.d-rh /etc/init.d/migrid
+COPY migrid-httpd-init.sh /etc/sysconfig/apache-minimal
 COPY apache-init-helper /etc/init.d/apache-minimal
 
 WORKDIR $MIG_ROOT

--- a/apache-init-helper
+++ b/apache-init-helper
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-#	/etc/rc.d/init.d/apache
+#	/etc/rc.d/init.d/apache-minimal
 #
 #	A simple apache httpd wrapper for docker-migrid container use
 #
@@ -12,7 +12,7 @@
 #	    status  - report apache httpd status
 #
 #	Customization of the httpd installation should be specified by
-#	variables in /etc/sysconfig/apache
+#	variables in /etc/sysconfig/apache-minimal
 #
 # Made from the template /usr/share/doc/initscripts-X/sysinitvfiles
 # from our CentOS installation
@@ -22,7 +22,7 @@
 # chkconfig: - 90 10
 # description: Apache httpd is a web server
 # processname: httpd
-# config: /etc/sysconfig/apache
+# config: /etc/sysconfig/apache-minimal
 # 
 
 # Source function library.
@@ -31,8 +31,8 @@
 # <define any local shell functions used by the code that follows>
 
 # first, pull in custom configuration (if it exists):
-if [ -f /etc/sysconfig/apache ]; then
-    . /etc/sysconfig/apache
+if [ -f /etc/sysconfig/apache-minimal ]; then
+    . /etc/sysconfig/apache-minimal
 fi
 # define default locations and user for MiG if not set:
 if [ -z "$MIG_USER" ]; then 
@@ -60,7 +60,7 @@ DAEMON_PATH="/usr/sbin/httpd"
 PID_FILE="$PID_DIR/httpd/httpd.pid"
 
 show_usage() {
-    echo "Usage: apache {start|stop|status|restart|reload}"
+    echo "Usage: apache-minimal {start|stop|status|restart|reload}"
 }
 
 start_apache() {

--- a/apache-init-helper
+++ b/apache-init-helper
@@ -1,0 +1,120 @@
+#!/bin/bash
+#
+#	/etc/rc.d/init.d/apache
+#
+#	A simple apache httpd wrapper for docker-migrid container use
+#
+#	Recognized arguments:
+#	    start   - start apache httpd
+#	    stop    - terminate apache httpd
+#	    restart - terminate and start apache httpd
+#	    reload  - reload apache httpd
+#	    status  - report apache httpd status
+#
+#	Customization of the httpd installation should be specified by
+#	variables in /etc/sysconfig/apache
+#
+# Made from the template /usr/share/doc/initscripts-X/sysinitvfiles
+# from our CentOS installation
+#
+# <tags ...>
+#
+# chkconfig: - 90 10
+# description: Apache httpd is a web server
+# processname: httpd
+# config: /etc/sysconfig/apache
+# 
+
+# Source function library.
+. /etc/init.d/functions
+
+# <define any local shell functions used by the code that follows>
+
+# first, pull in custom configuration (if it exists):
+if [ -f /etc/sysconfig/apache ]; then
+    . /etc/sysconfig/apache
+fi
+# define default locations and user for MiG if not set:
+if [ -z "$MIG_USER" ]; then 
+    MIG_USER=mig
+fi
+if [ -z "$MIG_PATH" ]; then
+    MIG_PATH=/home/${MIG_USER}
+fi
+# more configurable paths:
+if [ -z "$MIG_STATE" ]; then 
+    MIG_STATE=${MIG_PATH}/state
+fi
+if [ -z "$MIG_CODE" ]; then 
+    MIG_CODE=${MIG_PATH}/mig
+fi
+# Needed for absolute mig.X imports which are now required by PEP8
+if [ -z "$PYTHONPATH" ]; then
+    export PYTHONPATH=${MIG_PATH}
+else
+    export PYTHONPATH=${MIG_PATH}:$PYTHONPATH
+fi
+# you probably do not want to modify these...
+PID_DIR="${PID_DIR:-/var/run}"
+DAEMON_PATH="/usr/sbin/httpd"
+PID_FILE="$PID_DIR/httpd/httpd.pid"
+
+show_usage() {
+    echo "Usage: apache {start|stop|status|restart|reload}"
+}
+
+start_apache() {
+    echo -n "Starting apache httpd server"
+    ${DAEMON_PATH} -k start
+    RET2=$?
+    [ $RET2 ] && success
+    echo
+    [ $RET2 ] || echo "Warning: httpd not started."
+    echo
+}
+
+stop_apache() {
+    echo -n "Shutting down apache httpd server"
+    killproc ${DAEMON_PATH}
+    echo
+}
+
+reload_apache() {
+    echo -n "Reloading apache httpd server"
+    killproc ${DAEMON_PATH} -HUP
+    echo
+}
+
+status_apache() {
+    status ${DAEMON_PATH}
+}
+
+
+### Main ###
+
+# Exit cleanly if main daemon is missing
+test -f ${DAEMON_PATH} || exit 0
+
+case "$1" in
+    start)
+        start_apache
+	;;
+    stop)
+        stop_apache
+	;;
+    status)
+        status_apache
+	;;
+    restart)
+        stop_apache
+        start_apache
+	;;
+    reload)
+        reload_apache
+	;;
+    *)
+	show_usage
+	exit 1
+	;;
+esac
+exit $?

--- a/docker-entry.sh
+++ b/docker-entry.sh
@@ -128,9 +128,8 @@ for svc in ${RUN_SERVICES}; do
         # Load required httpd environment vars
         source migrid-httpd-init.sh
 
-        # TODO: can we switch to proper service start?
-        #service httpd start
-        /usr/sbin/httpd -k start
+	# Use simple apache init wrapper to allow restart without systemd need
+        service apache-minimal start
         status=$?
         if [ $status -ne 0 ]; then
             echo "Failed to start $svc: $status"


### PR DESCRIPTION
Introduce simple apache init wrapper to manage service inside container and ease e.g. restart upon LetsEncrypt certificate renewal.