### PR TITLE
Install custom openstacksdk version

### DIFF
--- a/.spellcheck-wordlist.txt
+++ b/.spellcheck-wordlist.txt
@@ -360,3 +360,5 @@ srvrco
 SSHFP
 userinfo
 migcheckssl
+OPENSTACKSDK
+openstacksdk

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -114,6 +114,7 @@ ARG ENABLE_JUPYTER=True
 ARG ENABLE_CLOUD=False
 ARG CLOUD_ACCESS=cloud-access.yaml
 ARG CLOUD_JUMPHOST_KEY=cloud-jumphost-key
+ARG OPENSTACKSDK_VERSION_OVERRIDE=
 ARG ENABLE_MIGADMIN=False
 ARG ENABLE_GDP=False
 ARG ENABLE_TWOFACTOR=True
@@ -758,6 +759,7 @@ ARG WITH_PY3
 ARG MODERN_WSGIDAV
 ARG UPGRADE_PARAMIKO
 ARG ENABLE_CLOUD
+ARG OPENSTACKSDK_VERSION_OVERRIDE
 ARG TRAC_ADMIN_PATH
 
 # NOTE: Switch back to root for system-wide pip install here
@@ -805,9 +807,16 @@ RUN if [ "${UPGRADE_PARAMIKO}" = "True" ]; then \
 # NOTE: openstacksdk-1.5 may have introduced typing conflicts here
 # NOTE: keystoneauth1-4.x introduced unresolvable 'pbr' deps on py2 here
 RUN if [ "${ENABLE_CLOUD}" = "True" ]; then \
-      pip2 install PyYAML==3.13 'openstacksdk<1.5' 'keystoneauth1<4' 'python-openstackclient<5'; \
+      pip2 install PyYAML==3.13 'openstacksdk<1.5' 'keystoneauth1<4' \
+                   'python-openstackclient<5'; \
+      if [ -n "${OPENSTACKSDK_VERSION_OVERRIDE}" ]; then \
+        pip2 install "openstacksdk==${OPENSTACKSDK_VERSION_OVERRIDE}" ; \
+      fi; \
       if [ "${WITH_PY3}" = "True" ]; then \
         pip3 install PyYAML==3.13 'openstacksdk<1.5' 'python-openstackclient<6'; \
+        if [ -n "${OPENSTACKSDK_VERSION_OVERRIDE}" ]; then \
+          pip3 install "openstacksdk==${OPENSTACKSDK_VERSION_OVERRIDE}" ; \
+        fi; \
       fi; \
     fi;
 
@@ -1371,6 +1380,7 @@ RUN if [ "${ENABLE_CLOUD}" = "True" ]; then \
         ln -s ../../state/secrets/${CLOUD_ACCESS} .config/openstack/clouds.yaml ; \
         [ -n "${CLOUD_JUMPHOST_KEY}" ] || CLOUD_JUMPHOST_KEY="cloud-jumphost-key" ; \ 
         ln -s ../state/secrets/${CLOUD_JUMPHOST_KEY} .ssh/${CLOUD_JUMPHOST_KEY} ; \
+        ln -s ../state/secrets/${CLOUD_JUMPHOST_KEY}.pub .ssh/${CLOUD_JUMPHOST_KEY}.pub ; \
     fi;
 
 # link relevant py trac ini into default location if no TRAC_INI_PATH is set here

--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -114,6 +114,7 @@ ARG ENABLE_JUPYTER=True
 ARG ENABLE_CLOUD=False
 ARG CLOUD_ACCESS=cloud-access.yaml
 ARG CLOUD_JUMPHOST_KEY=cloud-jumphost-key
+ARG OPENSTACKSDK_VERSION_OVERRIDE=
 ARG ENABLE_MIGADMIN=False
 ARG ENABLE_GDP=False
 ARG ENABLE_TWOFACTOR=True
@@ -775,6 +776,7 @@ ARG WITH_PY3
 ARG MODERN_WSGIDAV
 ARG UPGRADE_PARAMIKO
 ARG ENABLE_CLOUD
+ARG OPENSTACKSDK_VERSION_OVERRIDE
 ARG TRAC_ADMIN_PATH
 
 # NOTE: Switch back to root for system-wide pip install here
@@ -826,8 +828,14 @@ RUN if [ "${UPGRADE_PARAMIKO}" = "True" ]; then \
 RUN if [ "${ENABLE_CLOUD}" = "True" ]; then \
       pip2 install PyYAML==3.12 'openstacksdk<2' 'python-cinderclient<6' \
                    'python-openstackclient<5'; \
+      if [ -n "${OPENSTACKSDK_VERSION_OVERRIDE}" ]; then \
+        pip2 install "openstacksdk==${OPENSTACKSDK_VERSION_OVERRIDE}" ; \
+      fi; \
       if [ "${WITH_PY3}" = "True" ]; then \
         pip3 install PyYAML==3.12 'openstacksdk<1.5' 'python-openstackclient<6'; \
+        if [ -n "${OPENSTACKSDK_VERSION_OVERRIDE}" ]; then \
+          pip3 install "openstacksdk==${OPENSTACKSDK_VERSION_OVERRIDE}" ; \
+        fi; \
       fi; \
     fi;
 
@@ -1391,6 +1399,7 @@ RUN if [ "${ENABLE_CLOUD}" = "True" ]; then \
         ln -s ../../state/secrets/${CLOUD_ACCESS} .config/openstack/clouds.yaml ; \
         [ -n "${CLOUD_JUMPHOST_KEY}" ] || CLOUD_JUMPHOST_KEY="cloud-jumphost-key" ; \ 
         ln -s ../state/secrets/${CLOUD_JUMPHOST_KEY} .ssh/${CLOUD_JUMPHOST_KEY} ; \
+        ln -s ../state/secrets/${CLOUD_JUMPHOST_KEY}.pub .ssh/${CLOUD_JUMPHOST_KEY}.pub ; \
     fi;
 
 # link relevant py trac ini into default location if no TRAC_INI_PATH is set here

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -115,6 +115,7 @@ ARG ENABLE_JUPYTER=True
 ARG ENABLE_CLOUD=False
 ARG CLOUD_ACCESS=cloud-access.yaml
 ARG CLOUD_JUMPHOST_KEY=cloud-jumphost-key
+ARG OPENSTACKSDK_VERSION_OVERRIDE=
 ARG ENABLE_MIGADMIN=False
 ARG ENABLE_GDP=False
 ARG ENABLE_TWOFACTOR=True
@@ -732,6 +733,7 @@ ARG WITH_PY3
 ARG MODERN_WSGIDAV
 ARG UPGRADE_PARAMIKO
 ARG ENABLE_CLOUD
+ARG OPENSTACKSDK_VERSION_OVERRIDE
 ARG TRAC_ADMIN_PATH
 
 # NOTE: Switch back to root for system-wide pip install here
@@ -761,12 +763,16 @@ RUN if [ "${UPGRADE_PARAMIKO}" = "True" ]; then \
       fi; \
     fi;
 
-# NOTE: openstackclient is available in dnf here
-#RUN if [ "${ENABLE_CLOUD}" = "True" ]; then \
-#      if [ "${WITH_PY3}" = "True" ]; then \
-#        pip3 install python-openstackclient; \
-#      fi; \
-#    fi;
+# NOTE: openstackclient is available in dnf here, but sdk may be requested
+#       e.g. to work around version 1.0.0 breaking floating IP assignment
+RUN if [ "${ENABLE_CLOUD}" = "True" ]; then \
+      #if [ "${WITH_PY3}" = "True" ]; then \
+      #  pip3 install python-openstackclient; \
+      #fi; \
+      if [ -n "${OPENSTACKSDK_VERSION_OVERRIDE}" ]; then \
+        pip3 install "openstacksdk==${OPENSTACKSDK_VERSION_OVERRIDE}" ; \
+      fi; \
+    fi;
 
 # OpenID support in python (python-openid2 for py3) - use alternative from dnf 
 #RUN pip3 install python-openid2;
@@ -1269,6 +1275,7 @@ RUN if [ "${ENABLE_CLOUD}" = "True" ]; then \
         ln -s ../../state/secrets/${CLOUD_ACCESS} .config/openstack/clouds.yaml ; \
         [ -n "${CLOUD_JUMPHOST_KEY}" ] || CLOUD_JUMPHOST_KEY="cloud-jumphost-key" ; \ 
         ln -s ../state/secrets/${CLOUD_JUMPHOST_KEY} .ssh/${CLOUD_JUMPHOST_KEY} ; \
+        ln -s ../state/secrets/${CLOUD_JUMPHOST_KEY}.pub .ssh/${CLOUD_JUMPHOST_KEY}.pub ; \
     fi;
 
 # link relevant py trac ini into default location if no TRAC_INI_PATH is set here

--- a/doc/source/sections/configuration/variables.rst
+++ b/doc/source/sections/configuration/variables.rst
@@ -421,7 +421,7 @@ Variables
      - The name of the cloud jumphost ssh key file to use for managing user ssh keys on the cloud jumphost if the optional cloud integration is enabled (ENABLE_CLOUD).
    * - OPENSTACKSDK_VERSION_OVERRIDE
      -
-     - Install this particular custom openstacksdk package version specifically if it and ENABLE_CLOUD is set. E.g. useful to install a pre-1.0.0 version with older OpenStack clouds to get floating IP assignment working there.
+     - Install this particular custom openstacksdk package version specifically if it and ENABLE_CLOUD is set. E.g. useful to install a version prior to 1.0.0 with older OpenStack clouds to get floating IP assignment working there.
    * - ENABLE_MIGADMIN
      - False
      - Enable the built-in Server Admin feature for web based management of external user, log inspection, etc.

--- a/doc/source/sections/configuration/variables.rst
+++ b/doc/source/sections/configuration/variables.rst
@@ -419,6 +419,9 @@ Variables
    * - CLOUD_JUMPHOST_KEY
      - cloud-jumphost-key
      - The name of the cloud jumphost ssh key file to use for managing user ssh keys on the cloud jumphost if the optional cloud integration is enabled (ENABLE_CLOUD).
+   * - OPENSTACKSDK_VERSION_OVERRIDE
+     -
+     - Install this particular custom openstacksdk package version specifically if it and ENABLE_CLOUD is set. E.g. useful to install a pre-1.0.0 version with older OpenStack clouds to get floating IP assignment working there.
    * - ENABLE_MIGADMIN
      - False
      - Enable the built-in Server Admin feature for web based management of external user, log inspection, etc.


### PR DESCRIPTION
Add new OPENSTACKSDK_VERSION_OVERRIDE env to support installing a custom openstacksdk version specifically if it and ENABLE_CLOUD is set. Mainly to allow downgrading the default rocky9 version 1.0.1 of openstack to a version before the 1.0.0 version, which broke floating IP assignment on our own installation.