### PR TITLE
Force utf8 locale in all migrid services

### DIFF
--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -1519,8 +1519,6 @@ RUN if [ "${ENABLE_LOGROTATE}" = "True" ]; then \
 
 # Init scripts
 RUN cp generated-confs/migrid-init.d-rh /etc/init.d/migrid
-COPY migrid-httpd-init.sh /etc/sysconfig/apache-minimal
-COPY apache-init-helper /etc/init.d/apache-minimal
 
 WORKDIR $MIG_ROOT
 
@@ -1619,6 +1617,10 @@ ENTRYPOINT ["/tini", "--"]
 ADD docker-entry.sh /app/docker-entry.sh
 ADD migrid-httpd.env /app/migrid-httpd.env
 ADD migrid-httpd-init.sh /app/migrid-httpd-init.sh
+ADD apache-init-helper /etc/init.d/apache-minimal
+# NOTE: inherit explicit LANG set above for apache and migrid services
+RUN sed "s/#LANG=.*/LANG=${LANG}/g" /app/migrid-httpd-init.sh > /etc/sysconfig/apache-minimal
+RUN grep LANG /etc/sysconfig/apache-minimal > /etc/sysconfig/migrid
 RUN chown $USER:$GROUP /app/docker-entry.sh \
     && chmod +x /app/docker-entry.sh
 

--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -1544,8 +1544,6 @@ RUN if [ "${ENABLE_LOGROTATE}" = "True" ]; then \
 
 # Init scripts
 RUN cp generated-confs/migrid-init.d-rh /etc/init.d/migrid
-COPY migrid-httpd-init.sh /etc/sysconfig/apache-minimal
-COPY apache-init-helper /etc/init.d/apache-minimal
 
 WORKDIR $MIG_ROOT
 
@@ -1644,6 +1642,10 @@ ENTRYPOINT ["/tini", "--"]
 ADD docker-entry.sh /app/docker-entry.sh
 ADD migrid-httpd.env /app/migrid-httpd.env
 ADD migrid-httpd-init.sh /app/migrid-httpd-init.sh
+ADD apache-init-helper /etc/init.d/apache-minimal
+# NOTE: inherit explicit LANG set above for apache and migrid services
+RUN sed "s/#LANG=.*/LANG=${LANG}/g" /app/migrid-httpd-init.sh > /etc/sysconfig/apache-minimal
+RUN grep LANG /etc/sysconfig/apache-minimal > /etc/sysconfig/migrid
 RUN chown $USER:$GROUP /app/docker-entry.sh \
     && chmod +x /app/docker-entry.sh
 

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -1517,8 +1517,9 @@ ADD docker-entry.sh /app/docker-entry.sh
 ADD migrid-httpd.env /app/migrid-httpd.env
 ADD migrid-httpd-init.sh /app/migrid-httpd-init.sh
 ADD apache-init-helper /etc/init.d/apache-minimal
-# NOTE: inherit LANG set above for apache
+# NOTE: inherit explicit LANG set above for apache and migrid services
 RUN sed "s/#LANG=.*/LANG=${LANG}/g" /app/migrid-httpd-init.sh > /etc/sysconfig/apache-minimal
+RUN grep LANG /etc/sysconfig/apache-minimal > /etc/sysconfig/migrid
 RUN chown $USER:$GROUP /app/docker-entry.sh \
     && chmod +x /app/docker-entry.sh
 


### PR DESCRIPTION
Reuse explicit `LANG` locale setup from `apache-minimal` service helper in `migrid` init script in order to have consistent sane locale in all `migrid` services. This is mainly in relation to the encoding issues we noticed with exotic characters in the `MiGserver.conf` when implicitly loaded and parsed as ascii in the sftpsubsys PAM module in containers.

This PR should obsolete https://github.com/ucphhpc/migrid-sync/pull/177 .