### PR TITLE
Flexible site-conf.js selection during build

### DIFF
--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -1370,8 +1370,12 @@ RUN python2 ./generateconfs.py --source=. \
 
 RUN cp generated-confs/MiGserver.conf $MIG_ROOT/mig/server/ \
     && cp generated-confs/static-skin.css $MIG_ROOT/mig/images/ \
-    && cp generated-confs/index.html $MIG_ROOT/state/user_home/ \
-    && cp $MIG_ROOT/mig/images/site-conf-${EMULATE_FQDN}.js $MIG_ROOT/mig/images/site-conf.js
+    && cp generated-confs/index.html $MIG_ROOT/state/user_home/
+
+# Site conf for js helpers including status page and auth options on index page
+RUN [ -e "$MIG_ROOT/mig/images/site-conf-${DOMAIN}.js" ] || \
+    cp -a $MIG_ROOT/mig/images/site-conf-${EMULATE_FQDN}.js \
+       $MIG_ROOT/mig/images/site-conf-${DOMAIN}.js
 
 # Add a couple of named pipes for communicating with grid_X daemons
 RUN cd $MIG_ROOT && mkfifo mig/server/server.stdin && mkfifo mig/server/notify.stdin
@@ -1499,6 +1503,7 @@ RUN ln -s index-${DOMAIN}.html $MIG_ROOT/state/wwwpublic/index.html && \
     ln -s support-${EMULATE_FQDN}.html $MIG_ROOT/state/wwwpublic/support-snippet.html && \
     ln -s tips-${EMULATE_FQDN}.html $MIG_ROOT/state/wwwpublic/tips-snippet.html && \
     ln -s terms-${EMULATE_FQDN}.html $MIG_ROOT/state/wwwpublic/terms-snippet.html && \
+    ln -s site-conf-${DOMAIN}.js $MIG_ROOT/mig/images/site-conf.js && \
     # Make an empty template for status popup and status page to use.
     # For inspiration on how to use it please refer to the samples at
     # https://github.com/ucphhpc/migrid-ucph-sites/tree/main/state/wwwpublic

--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -1389,8 +1389,12 @@ RUN ./generateconfs.py --source=. \
 
 RUN cp generated-confs/MiGserver.conf $MIG_ROOT/mig/server/ \
     && cp generated-confs/static-skin.css $MIG_ROOT/mig/images/ \
-    && cp generated-confs/index.html $MIG_ROOT/state/user_home/ \
-    && cp $MIG_ROOT/mig/images/site-conf-${EMULATE_FQDN}.js $MIG_ROOT/mig/images/site-conf.js
+    && cp generated-confs/index.html $MIG_ROOT/state/user_home/
+
+# Site conf for js helpers including status page and auth options on index page
+RUN [ -e "$MIG_ROOT/mig/images/site-conf-${DOMAIN}.js" ] || \
+    cp -a $MIG_ROOT/mig/images/site-conf-${EMULATE_FQDN}.js \
+       $MIG_ROOT/mig/images/site-conf-${DOMAIN}.js
 
 # Add a couple of named pipes for communicating with grid_X daemons
 RUN cd $MIG_ROOT && mkfifo mig/server/server.stdin && mkfifo mig/server/notify.stdin
@@ -1524,6 +1528,7 @@ RUN ln -s index-${DOMAIN}.html $MIG_ROOT/state/wwwpublic/index.html && \
     ln -s support-${EMULATE_FQDN}.html $MIG_ROOT/state/wwwpublic/support-snippet.html && \
     ln -s tips-${EMULATE_FQDN}.html $MIG_ROOT/state/wwwpublic/tips-snippet.html && \
     ln -s terms-${EMULATE_FQDN}.html $MIG_ROOT/state/wwwpublic/terms-snippet.html && \
+    ln -s site-conf-${DOMAIN}.js $MIG_ROOT/mig/images/site-conf.js && \
     # Make an empty template for status popup and status page to use.
     # For inspiration on how to use it please refer to the samples at
     # https://github.com/ucphhpc/migrid-ucph-sites/tree/main/state/wwwpublic

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -1265,8 +1265,12 @@ RUN ./generateconfs.py --source=. \
 
 RUN cp generated-confs/MiGserver.conf $MIG_ROOT/mig/server/ \
     && cp generated-confs/static-skin.css $MIG_ROOT/mig/images/ \
-    && cp generated-confs/index.html $MIG_ROOT/state/user_home/ \
-    && cp $MIG_ROOT/mig/images/site-conf-${EMULATE_FQDN}.js $MIG_ROOT/mig/images/site-conf.js
+    && cp generated-confs/index.html $MIG_ROOT/state/user_home/
+
+# Site conf for js helpers including status page and auth options on index page
+RUN [ -e "$MIG_ROOT/mig/images/site-conf-${DOMAIN}.js" ] || \
+    cp -a $MIG_ROOT/mig/images/site-conf-${EMULATE_FQDN}.js \
+       $MIG_ROOT/mig/images/site-conf-${DOMAIN}.js
 
 # Add a couple of named pipes for communicating with grid_X daemons
 RUN cd $MIG_ROOT && mkfifo mig/server/server.stdin && mkfifo mig/server/notify.stdin
@@ -1398,6 +1402,7 @@ RUN ln -s index-${DOMAIN}.html $MIG_ROOT/state/wwwpublic/index.html && \
     ln -s support-${EMULATE_FQDN}.html $MIG_ROOT/state/wwwpublic/support-snippet.html && \
     ln -s tips-${EMULATE_FQDN}.html $MIG_ROOT/state/wwwpublic/tips-snippet.html && \
     ln -s terms-${EMULATE_FQDN}.html $MIG_ROOT/state/wwwpublic/terms-snippet.html && \
+    ln -s site-conf-${DOMAIN}.js $MIG_ROOT/mig/images/site-conf.js && \
     # Make an empty template for status popup and status page to use.
     # For inspiration on how to use it please refer to the samples at
     # https://github.com/ucphhpc/migrid-ucph-sites/tree/main/state/wwwpublic


### PR DESCRIPTION
Set up `site-conf.js` to point to any matching `site-conf-{$DOMAIN}.js` with fallback to the one for `EMULATE_DOMAIN` if no site-conf exists for `DOMAIN`. Similar to how the `index.html` page is chosen and useful e.g. in relation to status site deployments.

This is still untested in action so only a draft PR for now.