### PR TITLE
Add 'PATH' variable to migrid-httpd.env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,6 +221,7 @@ dockervolumeclean:
 
 clean:
 	rm -f docker-compose_shared.yml
+	rm -f migrid-httpd-init.sh
 	rm -fr ./mig
 	rm -fr ./httpd
 	# NOTE: certs may be injected or symlink to externally maintained dir.

--- a/migrid-httpd.env
+++ b/migrid-httpd.env
@@ -5,7 +5,7 @@
 #unset HOME
 
 # Set PATH used by migrid (and helper packages) in eg. python subprocess calls
-PATH="PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin"
+PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin"
 
 # Distro-specific name of apache httpd daemon binary
 APACHE_DAEMON="httpd"

--- a/migrid-httpd.env
+++ b/migrid-httpd.env
@@ -4,6 +4,9 @@
 # this won't be correct after changing uid
 #unset HOME
 
+# Set PATH used by migrid (and helper packages) in eg. python subprocess calls
+PATH="PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin"
+
 # Distro-specific name of apache httpd daemon binary
 APACHE_DAEMON="httpd"
 
@@ -42,6 +45,7 @@ APACHE_ARGUMENTS=-f ${APACHE_ETC_DIR}/${APACHE_DAEMON}.conf -d ${APACHE_ETC_DIR}
 #export APACHE_ETC_DIR
 #export APACHE_ARGUMENTS
 #export LANG
+#export PATH
 
 ## The command to get the status for 'apache(2)?ctl status'.
 ## Some packages providing 'www-browser' need '--dump' instead of '-dump'.


### PR DESCRIPTION
Binaries installed in '/usr/local/X' are currently not accessible through migrid httpd. The result is that eg. 'pdfkit' (used to generate SIF project emails) can't load it's helper binaries and thereby fails.