### PR TITLE
Fix the signature link, which is for security.txt rather than the pub keys

### DIFF
--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -1519,10 +1519,10 @@ RUN ln -s index-${DOMAIN}.html $MIG_ROOT/state/wwwpublic/index.html && \
         $MIG_ROOT/state/wwwpublic/site-privacy-policy.pdf && \
     ln -s security-${DOMAIN}.txt \
         $MIG_ROOT/state/wwwpublic/.well-known/security.txt && \
+    ln -s security-${DOMAIN}.txt.asc \
+        $MIG_ROOT/state/wwwpublic/.well-known/security.txt.asc && \
     ln -s security-pub-keys-${DOMAIN}.txt \
         $MIG_ROOT/state/wwwpublic/.well-known/security-pub-keys.txt && \
-    ln -s security-pub-keys-${DOMAIN}.txt.asc \
-        $MIG_ROOT/state/wwwpublic/.well-known/security-pub-keys.txt.asc && \
     ln -s security-disclosure-policy-${DOMAIN}.txt \
         $MIG_ROOT/state/wwwpublic/.well-known/security-disclosure-policy.txt && \
     chown -R $USER:$GROUP $MIG_ROOT/state/wwwpublic/*.html

--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -1543,10 +1543,10 @@ RUN ln -s index-${DOMAIN}.html $MIG_ROOT/state/wwwpublic/index.html && \
         $MIG_ROOT/state/wwwpublic/site-privacy-policy.pdf && \
     ln -s security-${DOMAIN}.txt \
         $MIG_ROOT/state/wwwpublic/.well-known/security.txt && \
+    ln -s security-${DOMAIN}.txt.asc \
+        $MIG_ROOT/state/wwwpublic/.well-known/security.txt.asc && \
     ln -s security-pub-keys-${DOMAIN}.txt \
         $MIG_ROOT/state/wwwpublic/.well-known/security-pub-keys.txt && \
-    ln -s security-pub-keys-${DOMAIN}.txt.asc \
-        $MIG_ROOT/state/wwwpublic/.well-known/security-pub-keys.txt.asc && \
     ln -s security-disclosure-policy-${DOMAIN}.txt \
         $MIG_ROOT/state/wwwpublic/.well-known/security-disclosure-policy.txt && \
     chown -R $USER:$GROUP $MIG_ROOT/state/wwwpublic/*.html

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -1417,10 +1417,10 @@ RUN ln -s index-${DOMAIN}.html $MIG_ROOT/state/wwwpublic/index.html && \
         $MIG_ROOT/state/wwwpublic/site-privacy-policy.pdf && \
     ln -s security-${DOMAIN}.txt \
         $MIG_ROOT/state/wwwpublic/.well-known/security.txt && \
+    ln -s security-${DOMAIN}.txt.asc \
+        $MIG_ROOT/state/wwwpublic/.well-known/security.txt.asc && \
     ln -s security-pub-keys-${DOMAIN}.txt \
         $MIG_ROOT/state/wwwpublic/.well-known/security-pub-keys.txt && \
-    ln -s security-pub-keys-${DOMAIN}.txt.asc \
-        $MIG_ROOT/state/wwwpublic/.well-known/security-pub-keys.txt.asc && \
     ln -s security-disclosure-policy-${DOMAIN}.txt \
         $MIG_ROOT/state/wwwpublic/.well-known/security-disclosure-policy.txt && \
     chown -R $USER:$GROUP $MIG_ROOT/state/wwwpublic/*.html


### PR DESCRIPTION
Adjustment to also cover `security.txt.asc` signature file, which should have been included in PR92.