### PR TITLE
Point mod_auth_openidc to latest release if upgrade is requested (Rocky 8+9)

### DIFF
--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -579,7 +579,7 @@ RUN echo "UPGRADE_MOD_AUTH_OPENIDC: $UPGRADE_MOD_AUTH_OPENIDC"
 RUN if [ "$UPGRADE_MOD_AUTH_OPENIDC" = "True" ]; then \
         if [ -z "${UPGRADE_OIDC_AUTH_MOD_SRC}" ]; then \
 		echo "upgrading mod_auth_openidc from upstream release package"; \
-		UPGRADE_OIDC_AUTH_MOD_SRC="https://github.com/OpenIDC/mod_auth_openidc/releases/download/v2.4.16.5/mod_auth_openidc-2.4.16.5-1.el8.x86_64.rpm"; \
+		UPGRADE_OIDC_AUTH_MOD_SRC="https://github.com/OpenIDC/mod_auth_openidc/releases/download/v2.4.16.11/mod_auth_openidc-2.4.16.11-1.el8.x86_64.rpm"; \
 	else \
 		echo "upgrading mod_auth_openidc from ${UPGRADE_OIDC_AUTH_MOD_SRC}"; \
 	fi; \ 

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -538,7 +538,7 @@ RUN echo "UPGRADE_MOD_AUTH_OPENIDC: $UPGRADE_MOD_AUTH_OPENIDC"
 RUN if [ "$UPGRADE_MOD_AUTH_OPENIDC" = "True" ]; then \
         if [ -z "${UPGRADE_OIDC_AUTH_MOD_SRC}" ]; then \
 		echo "upgrading mod_auth_openidc from upstream release package"; \
-		UPGRADE_OIDC_AUTH_MOD_SRC="https://github.com/OpenIDC/mod_auth_openidc/releases/download/v2.4.16.5/mod_auth_openidc-2.4.16.5-1.el9.x86_64.rpm"; \
+		UPGRADE_OIDC_AUTH_MOD_SRC="https://github.com/OpenIDC/mod_auth_openidc/releases/download/v2.4.16.11/mod_auth_openidc-2.4.16.11-1.el9.x86_64.rpm"; \
 	else \
 		echo "upgrading mod_auth_openidc from ${UPGRADE_OIDC_AUTH_MOD_SRC}"; \
 	fi; \ 


### PR DESCRIPTION
Point mod_auth_openidc to latest release if upgrade is requested with `UPGRADE_MOD_AUTH_OPENIDC`, in order to address a potential security issue (CVE-2025-31492) as described in the associated release notes at https://github.com/OpenIDC/mod_auth_openidc/releases/tag/v2.4.16.11

It does NOT sound like we are affected, since we don't adjust the mentioned `OIDCProviderAuthRequestMethod` setting in docker-migrid or migrid. Still, it may make sense to have the option to easily upgrade with the security fix and other recent bug fixes included.

**NOTE**: we cannot generally upgrade on CentOS 7 as well, since upstream no longer provides the corresponding packages there without a commercial support contract.