### PR TITLE
Adjust paramiko version selection to fit docker linux distro

### DIFF
--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -139,7 +139,8 @@ ARG UPGRADE_MOD_AUTH_OPENIDC=False
 # NOTE: source for optional mod auth openidc upgrade - upstream release if left unset
 ARG UPGRADE_OIDC_CJOSE_SRC=""
 ARG UPGRADE_OIDC_AUTH_MOD_SRC=""
-ARG UPGRADE_PARAMIKO=False
+# NOTE: more recent paramiko is required e.g. for modern host key algo and security fixes
+ARG UPGRADE_PARAMIKO=True
 ARG PUBKEY_FROM_DNS=False
 ARG WITH_PY3=False
 ARG PREFER_PYTHON3=False

--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -143,6 +143,7 @@ ARG UPGRADE_MOD_AUTH_OPENIDC=False
 #       https://github.com/OpenIDC/mod_auth_openidc/releases
 ARG UPGRADE_OIDC_CJOSE_SRC=""
 ARG UPGRADE_OIDC_AUTH_MOD_SRC=""
+# NOTE: paramiko is a bit dated in OS repo - allow optional upgrade
 ARG UPGRADE_PARAMIKO=False
 ARG PUBKEY_FROM_DNS=False
 # NOTE: python2 support is going away in rocky8+

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -143,6 +143,7 @@ ARG UPGRADE_MOD_AUTH_OPENIDC=False
 #       https://github.com/OpenIDC/mod_auth_openidc/releases
 ARG UPGRADE_OIDC_CJOSE_SRC=""
 ARG UPGRADE_OIDC_AUTH_MOD_SRC=""
+# NOTE: paramiko is a bit dated in OS repo - allow optional upgrade
 ARG UPGRADE_PARAMIKO=False
 ARG PUBKEY_FROM_DNS=False
 # NOTE: python2 support is gone on rocky9+

--- a/development.env
+++ b/development.env
@@ -146,6 +146,7 @@ WWWSERVE_MAX_BYTES=-1
 # but using self-signed certs is already a bad hack.
 ENABLE_SELF_SIGNED_CERTS=True
 UPGRADE_MOD_AUTH_OPENIDC=False
+# NOTE: leave the choice of paramiko to the Dockerfile default here as it's only required on old distros
 UPGRADE_PARAMIKO=False
 PUBKEY_FROM_DNS=False
 # NOTE: stay with wsgidav-1.3 for python2 to avoid CVE-2022-41905, we already get 4.3+ for python3

--- a/development.env
+++ b/development.env
@@ -147,7 +147,7 @@ WWWSERVE_MAX_BYTES=-1
 ENABLE_SELF_SIGNED_CERTS=True
 UPGRADE_MOD_AUTH_OPENIDC=False
 # NOTE: leave the choice of paramiko to the Dockerfile default here as it's only required on old distros
-UPGRADE_PARAMIKO=False
+#UPGRADE_PARAMIKO=False
 PUBKEY_FROM_DNS=False
 # NOTE: stay with wsgidav-1.3 for python2 to avoid CVE-2022-41905, we already get 4.3+ for python3
 MODERN_WSGIDAV=False

--- a/development_gdp.env
+++ b/development_gdp.env
@@ -146,6 +146,7 @@ WWWSERVE_MAX_BYTES=-1
 # but using self-signed certs is already a bad hack.
 ENABLE_SELF_SIGNED_CERTS=True
 UPGRADE_MOD_AUTH_OPENIDC=False
+# NOTE: leave the choice of paramiko to the Dockerfile default here as it's only required on old distros
 UPGRADE_PARAMIKO=False
 PUBKEY_FROM_DNS=False
 # NOTE: stay with wsgidav-1.3 for python2 to avoid CVE-2022-41905, we already get 4.3+ for python3

--- a/development_gdp.env
+++ b/development_gdp.env
@@ -147,7 +147,7 @@ WWWSERVE_MAX_BYTES=-1
 ENABLE_SELF_SIGNED_CERTS=True
 UPGRADE_MOD_AUTH_OPENIDC=False
 # NOTE: leave the choice of paramiko to the Dockerfile default here as it's only required on old distros
-UPGRADE_PARAMIKO=False
+#UPGRADE_PARAMIKO=False
 PUBKEY_FROM_DNS=False
 # NOTE: stay with wsgidav-1.3 for python2 to avoid CVE-2022-41905, we already get 4.3+ for python3
 MODERN_WSGIDAV=False

--- a/doc/source/sections/configuration/variables.rst
+++ b/doc/source/sections/configuration/variables.rst
@@ -477,8 +477,8 @@ Variables
      - 
      - Optional custom source for the cjose OpenIDC dependency package if UPGRADE_MOD_AUTH_OPENIDC is requested 
    * - UPGRADE_PARAMIKO
-     - False
-     - Upgrade the default Paramiko version to latest supported one during build 
+     -
+     - Upgrade the default Paramiko version to latest supported one during build. Leave unset to pick default from active Dockerfile.
    * - PUBKEY_FROM_DNS
      - False
      - Advertize to SFTP users that they can find the host key in DNS(SEC).

--- a/production.env
+++ b/production.env
@@ -146,8 +146,8 @@ WWWSERVE_MAX_BYTES=-1
 ENABLE_SELF_SIGNED_CERTS=False
 #BUILD_MOD_AUTH_OPENID=False
 UPGRADE_MOD_AUTH_OPENIDC=True
-# Use a recent paramiko for modern host key algo support in grid_sftp (ENABLE_SFTP)
-UPGRADE_PARAMIKO=True
+# NOTE: leave the choice of paramiko to the Dockerfile default here as it's only required on old distros
+#UPGRADE_PARAMIKO=True
 PUBKEY_FROM_DNS=False
 # NOTE: stay with wsgidav-1.3 for python2 to avoid CVE-2022-41905, we already get 4.3+ for python3
 MODERN_WSGIDAV=False


### PR DESCRIPTION
We only really need to upgrade Paramiko on old legacy platforms like CentOS 7. So remove the default from example `env`s and leave it to the default in the active `Dockerfile`.
We have received reports about possible regressions with `UPGRADE_PARAMIKO` enabled on Rocky and shouldn't need upgrades there at the moment. 