### PR TITLE
Added missing miglog volume to the migrid-lustre-quota container

### DIFF
--- a/docker-compose_production.yml
+++ b/docker-compose_production.yml
@@ -728,6 +728,9 @@ services:
       - type: volume
         source: state
         target: /home/mig/state
+      - type: volume
+        source: log
+        target: /home/mig/state/log
     command: miglustrequota.py -c /home/mig/mig/server/MiGserver.conf
 
 # NOTE: not used in stand-alone production mode


### PR DESCRIPTION
Without the 'miglog' mount 'quota.log' is not written to 'LOG_ROOT' and in effect not persistent.