### PR TITLE
Added migrid-lustre-quota container syslog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,7 @@ initdirs: initcomposevars
 	mkdir -p ${LOG_ROOT}/syslog/migrid-sftp
 	mkdir -p ${LOG_ROOT}/syslog/migrid-webdavs
 	mkdir -p ${LOG_ROOT}/syslog/migrid-ftps
+	mkdir -p ${LOG_ROOT}/syslog/migrid-lustre-quota
 
 initcomposevars:
 	@echo "creating env variable map in docker-compose_shared.yml"

--- a/docker-compose_production.yml
+++ b/docker-compose_production.yml
@@ -1078,7 +1078,7 @@ volumes:
       o: bind
 
   migrid-lustre-quota-syslog:
-    # Volume used for exposing migrid ftps container system log
+    # Volume used for exposing migrid lustre quota container system log
     driver: local
     driver_opts:
       type: none

--- a/docker-compose_production.yml
+++ b/docker-compose_production.yml
@@ -741,6 +741,9 @@ services:
         source: mig
         target: /home/mig/mig
       - type: volume
+        source: migrid-lustre-quota-syslog
+        target: /var/log
+      - type: volume
         source: state
         target: /home/mig/state
       - type: volume
@@ -1072,4 +1075,12 @@ volumes:
     driver_opts:
       type: none
       device: ${LOG_ROOT}/syslog/migrid-ftps
+      o: bind
+
+  migrid-lustre-quota-syslog:
+    # Volume used for exposing migrid ftps container system log
+    driver: local
+    driver_opts:
+      type: none
+      device: ${LOG_ROOT}/syslog/migrid-lustre-quota
       o: bind


### PR DESCRIPTION
Add migrid-lustre-quota container syslog volume for alignment with the rest of the container setup.

My tests showed that nothing is written to the syslog while running the quota system, but who knows what happens in the future. Better to have empty logs than to miss logs when they are needed.