### PR TITLE
migrid-lustre-quota container: Added secrets volume

### DIFF
--- a/docker-compose_production.yml
+++ b/docker-compose_production.yml
@@ -750,6 +750,9 @@ services:
         source: log
         target: /home/mig/state/log
       - type: volume
+        source: secrets
+        target: /home/mig/state/secrets
+      - type: volume
         source: quota_home
         target: /home/mig/state/quota_home
       - type: volume


### PR DESCRIPTION
The 'migrid-lustre-quota' container doesn't use the secrets volume directly, but loading 'configuration' makes a lot of noise about not being able to load the specified 'secrets' files.