### PR TITLE
Intergrate conf snippets in `include_sections` from migrid PR244.

### DIFF
--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -1409,7 +1409,8 @@ RUN if [ -n "${TRAC_ADMIN_PATH}" -a -z "${TRAC_INI_PATH}" ]; then \
     fi;
 
 # Copy in any external conf sections to supplement generated MiGserver.conf
-COPY external-conf-sections/ mig/server/MiGserver.d/
+RUN mkdir -p $MIG_ROOT/mig/server/MiGserver.d
+COPY external-conf-sections/ $MIG_ROOT/mig/server/MiGserver.d/
 
 
 #------------------------- next stage -----------------------------#

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -1408,6 +1408,9 @@ RUN if [ -n "${TRAC_ADMIN_PATH}" -a -z "${TRAC_INI_PATH}" ]; then \
         fi; \
     fi;
 
+# Copy in any external conf sections to supplement generated MiGserver.conf
+COPY external-conf-sections/ mig/server/MiGserver.d/
+
 
 #------------------------- next stage -----------------------------#
 FROM --platform=linux/$ARCH install_mig AS setup_mig_configs

--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -1426,6 +1426,9 @@ RUN if [ -n "${TRAC_ADMIN_PATH}" -a -z "${TRAC_INI_PATH}" ]; then \
         fi; \
     fi;
 
+# Copy in any external conf sections to supplement generated MiGserver.conf
+COPY external-conf-sections/ mig/server/MiGserver.d/
+
 
 #------------------------- next stage -----------------------------#
 FROM --platform=linux/$ARCH install_mig AS setup_mig_configs

--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -1427,7 +1427,8 @@ RUN if [ -n "${TRAC_ADMIN_PATH}" -a -z "${TRAC_INI_PATH}" ]; then \
     fi;
 
 # Copy in any external conf sections to supplement generated MiGserver.conf
-COPY external-conf-sections/ mig/server/MiGserver.d/
+RUN mkdir -p $MIG_ROOT/mig/server/MiGserver.d
+COPY external-conf-sections/ $MIG_ROOT/mig/server/MiGserver.d/
 
 
 #------------------------- next stage -----------------------------#

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -1302,6 +1302,9 @@ RUN if [ -n "${TRAC_ADMIN_PATH}" -a -z "${TRAC_INI_PATH}" ]; then \
         fi; \
     fi;
 
+# Copy in any external conf sections to supplement generated MiGserver.conf
+COPY external-conf-sections/ mig/server/MiGserver.d/
+
 
 #------------------------- next stage -----------------------------#
 FROM --platform=linux/$ARCH install_mig AS setup_mig_configs

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -1303,7 +1303,8 @@ RUN if [ -n "${TRAC_ADMIN_PATH}" -a -z "${TRAC_INI_PATH}" ]; then \
     fi;
 
 # Copy in any external conf sections to supplement generated MiGserver.conf
-COPY external-conf-sections/ mig/server/MiGserver.d/
+RUN mkdir -p $MIG_ROOT/mig/server/MiGserver.d
+COPY external-conf-sections/ $MIG_ROOT/mig/server/MiGserver.d/
 
 
 #------------------------- next stage -----------------------------#

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ initdirs: initcomposevars
 	mkdir -p certs
 	mkdir -p httpd
 	mkdir -p mig
+	mkdir -p external-conf-sections
 	mkdir -p state
 	mkdir -p ${VOLATILE_ROOT}/mig_system_run
 	mkdir -p ${VOLATILE_ROOT}/openid_store
@@ -254,6 +255,7 @@ distclean: clean sitestateclean sitedataclean dockerclean dockervolumeclean
 	rm -fr ./external-certificates
 	# NOTE: certs remove in clean is conditional - always remove it here
 	rm -fr ./certs
+	rm -fr ./external-conf-sections
 	rm -f .env docker-compose.yml Dockerfile
 
 wipesitestatewarning:


### PR DESCRIPTION
Reuse the strategy from external-certificates folder for the new MiGserver.conf  `include_sections` support. Copies any files in the `external-conf-sections` folder into the resulting container `/home/mig/mig/server/MiGserver.d/` folder where they will be included by default.