### PR TITLE
An alternative integration of the mig server config extension snippets like PR105 using bind mount

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,7 @@ initdirs: initcomposevars
 	mkdir -p ${PERSISTENT_ROOT}/wwwpublic-vgrid
 	mkdir -p ${PERSISTENT_ROOT}/wwwpublic-download
 	mkdir -p ${PERSISTENT_ROOT}/secrets
+	mkdir -p ${PERSISTENT_ROOT}/mig-server-extconfs
 	mkdir -p ${LOG_ROOT}/miglog
 	mkdir -p ${LOG_ROOT}/syslog/migrid
 	mkdir -p ${LOG_ROOT}/syslog/migrid-io

--- a/docker-compose_production.yml
+++ b/docker-compose_production.yml
@@ -42,6 +42,9 @@ services:
         source: mig
         target: /home/mig/mig
       - type: volume
+        source: mig-server-extconfs
+        target: /home/mig/mig/server/MiGserver.d
+      - type: volume
         source: certs
         target: /etc/httpd/MiG-certificates
       - type: volume
@@ -92,6 +95,9 @@ services:
       - type: volume
         source: mig
         target: /home/mig/mig
+      - type: volume
+        source: mig-server-extconfs
+        target: /home/mig/mig/server/MiGserver.d
       - type: volume
         source: certs
         target: /etc/httpd/MiG-certificates
@@ -228,6 +234,9 @@ services:
         source: mig
         target: /home/mig/mig
       - type: volume
+        source: mig-server-extconfs
+        target: /home/mig/mig/server/MiGserver.d
+      - type: volume
         source: certs
         target: /etc/httpd/MiG-certificates
       - type: volume
@@ -357,6 +366,9 @@ services:
         source: mig
         target: /home/mig/mig
       - type: volume
+        source: mig-server-extconfs
+        target: /home/mig/mig/server/MiGserver.d
+      - type: volume
         source: certs
         target: /etc/httpd/MiG-certificates
       - type: volume
@@ -484,6 +496,9 @@ services:
       - type: volume
         source: mig
         target: /home/mig/mig
+      - type: volume
+        source: mig-server-extconfs
+        target: /home/mig/mig/server/MiGserver.d
       - type: volume
         source: certs
         target: /etc/httpd/MiG-certificates
@@ -613,6 +628,9 @@ services:
         source: mig
         target: /home/mig/mig
       - type: volume
+        source: mig-server-extconfs
+        target: /home/mig/mig/server/MiGserver.d
+      - type: volume
         source: certs
         target: /etc/httpd/MiG-certificates
       - type: volume
@@ -741,6 +759,9 @@ services:
         source: mig
         target: /home/mig/mig
       - type: volume
+        source: mig-server-extconfs
+        target: /home/mig/mig/server/MiGserver.d
+      - type: volume
         source: migrid-lustre-quota-syslog
         target: /var/log
       - type: volume
@@ -814,6 +835,14 @@ volumes:
     driver_opts:
       type: none
       device: ${DOCKER_MIGRID_ROOT}/mig
+      o: bind
+
+  mig-server-extconf:
+    # Volume used to contain the optional additional mig server config snippets
+    driver: local
+    driver_opts:
+      type: none
+      device: ${PERSISTENT_ROOT}/mig-server-extconfs
       o: bind
 
   state:


### PR DESCRIPTION
An alternative integration of the mig server config extension snippets like PR #105 but using a bind mounted volume in `PERSISTENT_ROOT` for the config snippets instead as agreed in the PR discussion. This will enable easy adjustment of e.g. the `CLOUD_X` sections where user access and such may need more frequent updates than what is feasible to handle with rebuild/redeploy every time.