### PR TITLE
Addition/jupyterhub ssl proxy config

### DIFF
--- a/.spellcheck-wordlist.txt
+++ b/.spellcheck-wordlist.txt
@@ -364,3 +364,6 @@ OPENSTACKSDK
 openstacksdk
 HTML
 html
+balancer
+JupyterHub
+SSLProxyCACertificateFile

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -225,6 +225,7 @@ ARG QUOTA_GOCRYPTFS_SOCK="/dev/null"
 
 # Jupyter Arguments
 ARG JUPYTER_SERVICES=""
+ARG JUPYTER_SERVICES_PROXY_CONFIG="{}"
 ARG JUPYTER_SERVICES_DESC="{}"
 # Cloud Arguments
 ARG CLOUD_SERVICES=""
@@ -1151,6 +1152,7 @@ ARG IO_ACCOUNT_EXPIRE
 ARG DATASAFETY_LINK
 ARG DATASAFETY_TEXT
 ARG JUPYTER_SERVICES
+ARG JUPYTER_SERVICES_PROXY_CONFIG
 ARG JUPYTER_SERVICES_DESC
 ARG CLOUD_SERVICES
 ARG CLOUD_SERVICES_DESC
@@ -1196,6 +1198,7 @@ RUN if [ "${PREFER_PYTHON3}" = "True" ]; then \
 WORKDIR $MIG_ROOT/mig/install
 
 RUN echo "Designated jupyter services: ${JUPYTER_SERVICES}"
+RUN echo "Designated jupyter services proxy config: ${JUPYTER_SERVICES_PROXY_CONFIG}"
 RUN echo "Designated jupyter services descriptions: ${JUPYTER_SERVICES_DESC}"
 RUN echo "Designated cloud services: ${CLOUD_SERVICES}"
 RUN echo "Designated cloud services descriptions: ${CLOUD_SERVICES_DESC}"
@@ -1321,6 +1324,7 @@ RUN python2 ./generateconfs.py --source=. \
     --wwwserve_max_bytes=${WWWSERVE_MAX_BYTES} \
     --password_policy=${MIG_PASSWORD_POLICY} \
     --jupyter_services="${JUPYTER_SERVICES}" \
+    --jupyter_services_proxy_config="${JUPYTER_SERVICES_PROXY_CONFIG}" \
     --jupyter_services_desc="${JUPYTER_SERVICES_DESC}" \
     --cloud_services="${CLOUD_SERVICES}" \
     --cloud_services_desc="${CLOUD_SERVICES_DESC}" \

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -225,6 +225,7 @@ ARG QUOTA_GOCRYPTFS_SOCK="/dev/null"
 
 # Jupyter Arguments
 ARG JUPYTER_SERVICES=""
+ARG JUPYTER_SERVICES_ENABLE_PROXY_HTTPS=True
 ARG JUPYTER_SERVICES_PROXY_CONFIG="{}"
 ARG JUPYTER_SERVICES_DESC="{}"
 # Cloud Arguments
@@ -1152,6 +1153,7 @@ ARG IO_ACCOUNT_EXPIRE
 ARG DATASAFETY_LINK
 ARG DATASAFETY_TEXT
 ARG JUPYTER_SERVICES
+ARG JUPYTER_SERVICES_ENABLE_PROXY_HTTPS
 ARG JUPYTER_SERVICES_PROXY_CONFIG
 ARG JUPYTER_SERVICES_DESC
 ARG CLOUD_SERVICES
@@ -1198,6 +1200,7 @@ RUN if [ "${PREFER_PYTHON3}" = "True" ]; then \
 WORKDIR $MIG_ROOT/mig/install
 
 RUN echo "Designated jupyter services: ${JUPYTER_SERVICES}"
+RUN echo "Designated jupyter services proxy enable https: ${JUPYTER_SERVICES_ENABLE_PROXY_HTTPS}"
 RUN echo "Designated jupyter services proxy config: ${JUPYTER_SERVICES_PROXY_CONFIG}"
 RUN echo "Designated jupyter services descriptions: ${JUPYTER_SERVICES_DESC}"
 RUN echo "Designated cloud services: ${CLOUD_SERVICES}"
@@ -1324,6 +1327,7 @@ RUN python2 ./generateconfs.py --source=. \
     --wwwserve_max_bytes=${WWWSERVE_MAX_BYTES} \
     --password_policy=${MIG_PASSWORD_POLICY} \
     --jupyter_services="${JUPYTER_SERVICES}" \
+    --jupyter_services_enable_proxy_https="${JUPYTER_SERVICES_ENABLE_PROXY_HTTPS}" \
     --jupyter_services_proxy_config="${JUPYTER_SERVICES_PROXY_CONFIG}" \
     --jupyter_services_desc="${JUPYTER_SERVICES_DESC}" \
     --cloud_services="${CLOUD_SERVICES}" \

--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -230,6 +230,7 @@ ARG QUOTA_GOCRYPTFS_SOCK="/dev/null"
 
 # Jupyter Arguments
 ARG JUPYTER_SERVICES=""
+ARG JUPYTER_SERVICES_ENABLE_PROXY_HTTPS=True
 ARG JUPYTER_SERVICES_PROXY_CONFIG="{}"
 ARG JUPYTER_SERVICES_DESC="{}"
 # Cloud Arguments
@@ -1170,6 +1171,7 @@ ARG IO_ACCOUNT_EXPIRE
 ARG DATASAFETY_LINK
 ARG DATASAFETY_TEXT
 ARG JUPYTER_SERVICES
+ARG JUPYTER_SERVICES_ENABLE_PROXY_HTTPS
 ARG JUPYTER_SERVICES_PROXY_CONFIG
 ARG JUPYTER_SERVICES_DESC
 ARG CLOUD_SERVICES
@@ -1216,6 +1218,7 @@ RUN if [ "${PREFER_PYTHON3}" = "True" ]; then \
 WORKDIR $MIG_ROOT/mig/install
 
 RUN echo "Designated jupyter services: ${JUPYTER_SERVICES}"
+RUN echo "Designated jupyter services proxy enable https: ${JUPYTER_SERVICES_ENABLE_PROXY_HTTPS}"
 RUN echo "Designated jupyter services proxy config: ${JUPYTER_SERVICES_PROXY_CONFIG}"
 RUN echo "Designated jupyter services descriptions: ${JUPYTER_SERVICES_DESC}"
 RUN echo "Designated cloud services: ${CLOUD_SERVICES}"
@@ -1342,6 +1345,7 @@ RUN ./generateconfs.py --source=. \
     --wwwserve_max_bytes=${WWWSERVE_MAX_BYTES} \
     --password_policy=${MIG_PASSWORD_POLICY} \
     --jupyter_services="${JUPYTER_SERVICES}" \
+    --jupyter_services_enable_proxy_https="${JUPYTER_SERVICES_ENABLE_PROXY_HTTPS}" \
     --jupyter_services_proxy_config="${JUPYTER_SERVICES_PROXY_CONFIG}" \
     --jupyter_services_desc="${JUPYTER_SERVICES_DESC}" \
     --cloud_services="${CLOUD_SERVICES}" \

--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -230,6 +230,7 @@ ARG QUOTA_GOCRYPTFS_SOCK="/dev/null"
 
 # Jupyter Arguments
 ARG JUPYTER_SERVICES=""
+ARG JUPYTER_SERVICES_PROXY_CONFIG="{}"
 ARG JUPYTER_SERVICES_DESC="{}"
 # Cloud Arguments
 ARG CLOUD_SERVICES=""
@@ -1169,6 +1170,7 @@ ARG IO_ACCOUNT_EXPIRE
 ARG DATASAFETY_LINK
 ARG DATASAFETY_TEXT
 ARG JUPYTER_SERVICES
+ARG JUPYTER_SERVICES_PROXY_CONFIG
 ARG JUPYTER_SERVICES_DESC
 ARG CLOUD_SERVICES
 ARG CLOUD_SERVICES_DESC
@@ -1214,6 +1216,7 @@ RUN if [ "${PREFER_PYTHON3}" = "True" ]; then \
 WORKDIR $MIG_ROOT/mig/install
 
 RUN echo "Designated jupyter services: ${JUPYTER_SERVICES}"
+RUN echo "Designated jupyter services proxy config: ${JUPYTER_SERVICES_PROXY_CONFIG}"
 RUN echo "Designated jupyter services descriptions: ${JUPYTER_SERVICES_DESC}"
 RUN echo "Designated cloud services: ${CLOUD_SERVICES}"
 RUN echo "Designated cloud services descriptions: ${CLOUD_SERVICES_DESC}"
@@ -1339,6 +1342,7 @@ RUN ./generateconfs.py --source=. \
     --wwwserve_max_bytes=${WWWSERVE_MAX_BYTES} \
     --password_policy=${MIG_PASSWORD_POLICY} \
     --jupyter_services="${JUPYTER_SERVICES}" \
+    --jupyter_services_proxy_config="${JUPYTER_SERVICES_PROXY_CONFIG}" \
     --jupyter_services_desc="${JUPYTER_SERVICES_DESC}" \
     --cloud_services="${CLOUD_SERVICES}" \
     --cloud_services_desc="${CLOUD_SERVICES_DESC}" \

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -230,6 +230,7 @@ ARG QUOTA_GOCRYPTFS_SOCK="/dev/null"
 
 # Jupyter Arguments
 ARG JUPYTER_SERVICES=""
+ARG JUPYTER_SERVICES_ENABLE_PROXY_HTTPS=True
 ARG JUPYTER_SERVICES_PROXY_CONFIG="{}"
 ARG JUPYTER_SERVICES_DESC="{}"
 # Cloud Arguments
@@ -1062,6 +1063,7 @@ ARG IO_ACCOUNT_EXPIRE
 ARG DATASAFETY_LINK
 ARG DATASAFETY_TEXT
 ARG JUPYTER_SERVICES
+ARG JUPYTER_SERVICES_ENABLE_PROXY_HTTPS
 ARG JUPYTER_SERVICES_PROXY_CONFIG
 ARG JUPYTER_SERVICES_DESC
 ARG CLOUD_SERVICES
@@ -1097,6 +1099,7 @@ RUN echo "PATH=$HOME/.local/bin:${PATH}" >> ~/.bash_profile \
 WORKDIR $MIG_ROOT/mig/install
 
 RUN echo "Designated jupyter services: ${JUPYTER_SERVICES}"
+RUN echo "Designated jupyter services proxy enable https: ${JUPYTER_SERVICES_ENABLE_PROXY_HTTPS}"
 RUN echo "Designated jupyter services proxy config: ${JUPYTER_SERVICES_PROXY_CONFIG}"
 RUN echo "Designated jupyter services descriptions: ${JUPYTER_SERVICES_DESC}"
 RUN echo "Designated cloud services: ${CLOUD_SERVICES}"
@@ -1218,6 +1221,7 @@ RUN ./generateconfs.py --source=. \
     --wwwserve_max_bytes=${WWWSERVE_MAX_BYTES} \
     --password_policy=${MIG_PASSWORD_POLICY} \
     --jupyter_services="${JUPYTER_SERVICES}" \
+    --jupyter_services_enable_proxy_https="${JUPYTER_SERVICES_ENABLE_PROXY_HTTPS}" \
     --jupyter_services_proxy_config="${JUPYTER_SERVICES_PROXY_CONFIG}" \
     --jupyter_services_desc="${JUPYTER_SERVICES_DESC}" \
     --cloud_services="${CLOUD_SERVICES}" \

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -230,6 +230,7 @@ ARG QUOTA_GOCRYPTFS_SOCK="/dev/null"
 
 # Jupyter Arguments
 ARG JUPYTER_SERVICES=""
+ARG JUPYTER_SERVICES_PROXY_CONFIG="{}"
 ARG JUPYTER_SERVICES_DESC="{}"
 # Cloud Arguments
 ARG CLOUD_SERVICES=""
@@ -1061,6 +1062,7 @@ ARG IO_ACCOUNT_EXPIRE
 ARG DATASAFETY_LINK
 ARG DATASAFETY_TEXT
 ARG JUPYTER_SERVICES
+ARG JUPYTER_SERVICES_PROXY_CONFIG
 ARG JUPYTER_SERVICES_DESC
 ARG CLOUD_SERVICES
 ARG CLOUD_SERVICES_DESC
@@ -1095,6 +1097,7 @@ RUN echo "PATH=$HOME/.local/bin:${PATH}" >> ~/.bash_profile \
 WORKDIR $MIG_ROOT/mig/install
 
 RUN echo "Designated jupyter services: ${JUPYTER_SERVICES}"
+RUN echo "Designated jupyter services proxy config: ${JUPYTER_SERVICES_PROXY_CONFIG}"
 RUN echo "Designated jupyter services descriptions: ${JUPYTER_SERVICES_DESC}"
 RUN echo "Designated cloud services: ${CLOUD_SERVICES}"
 RUN echo "Designated cloud services descriptions: ${CLOUD_SERVICES_DESC}"
@@ -1215,6 +1218,7 @@ RUN ./generateconfs.py --source=. \
     --wwwserve_max_bytes=${WWWSERVE_MAX_BYTES} \
     --password_policy=${MIG_PASSWORD_POLICY} \
     --jupyter_services="${JUPYTER_SERVICES}" \
+    --jupyter_services_proxy_config="${JUPYTER_SERVICES_PROXY_CONFIG}" \
     --jupyter_services_desc="${JUPYTER_SERVICES_DESC}" \
     --cloud_services="${CLOUD_SERVICES}" \
     --cloud_services_desc="${CLOUD_SERVICES_DESC}" \

--- a/doc/source/sections/configuration/variables.rst
+++ b/doc/source/sections/configuration/variables.rst
@@ -613,7 +613,10 @@ Variables
      - The number of worker processes started in the Apache service to handle all incoming web requests.Increase to allow handling more concurrent clients if needed but at the cost of higher system resource requirements.
    * - JUPYTER_SERVICES
      - ""
-     - Where the optional external Jupyter nodes can be reached
+     - Where the optional external Jupyter nodes can be reached. Expects the format "SERVICE_NAME.http(s)://url-or-ip-to-the-jupyter(hub)-node SERVICE_NAME.http(s)://url-or-ip-to-any-additional-jupyter(hub)-node"
+   * - JUPYTER_SERVICES_PROXY_CONFIG
+     - "{}"
+     - Additional Apache proxy configuration options that can be used to generated the underlying Apache reverse proxy configuration for reaching the Jupyter service. It is expected to be structured as a string formated dictionary and it currently supports the following keys, `enable_proxy_ssl` and `ssl_proxy_ca_certificate_file`. Therefore a potential config value could be "{'SERVICE_NAME': {'enable_proxy_ssl': True} }"
    * - JUPYTER_SERVICES_DESC
      - "{}"
      - A text to describe the optional external Jupyter nodes

--- a/doc/source/sections/configuration/variables.rst
+++ b/doc/source/sections/configuration/variables.rst
@@ -613,10 +613,13 @@ Variables
      - The number of worker processes started in the Apache service to handle all incoming web requests.Increase to allow handling more concurrent clients if needed but at the cost of higher system resource requirements.
    * - JUPYTER_SERVICES
      - ""
-     - Where the optional external Jupyter nodes can be reached. Expects the format "SERVICE_NAME.http(s)://url-or-ip-to-the-jupyter(hub)-node SERVICE_NAME.http(s)://url-or-ip-to-any-additional-jupyter(hub)-node"
+     - Where the optional external Jupyter nodes can be reached. Expects the format "SERVICE_NAME.http(s)://URL-or-IP-to-the-jupyter(hub)-node SERVICE_NAME.http(s)://URL-or-IP-to-any-additional-jupyter(hub)-node"
+   * - JUPYTER_SERVICES_ENABLE_PROXY_HTTPS
+     - True
+     - Whether or not the internal Apache reverse proxy configuration should use HTTPS or not when connecting to the designated JupyterHub service.
    * - JUPYTER_SERVICES_PROXY_CONFIG
      - "{}"
-     - Additional Apache proxy configuration options that can be used to generated the underlying Apache reverse proxy configuration for reaching the Jupyter service. It is expected to be structured as a string formated dictionary and it currently supports the following keys, `enable_proxy_ssl` and `ssl_proxy_ca_certificate_file`. Therefore a potential config value could be "{'SERVICE_NAME': {'enable_proxy_ssl': True} }"
+     - Can be set to add any additional Apache proxy balancer configuration options that should be used when establishing the HTTP(S) connection to the designated JupyterHub service. It is expected to be structured as a string formated dictionary that accepts any key attribute that is supported as an Apache mod_proxy_balancer proxy section option as can be seen at https://httpd.apache.org/docs/2.4/mod/mod_proxy_balancer.html. Therefore a potential config value could be "{'SSLProxyCACertificateFile': 'path/to/local/ca-certificate.pem'}"
    * - JUPYTER_SERVICES_DESC
      - "{}"
      - A text to describe the optional external Jupyter nodes

--- a/doc/source/sections/configuration/variables.rst
+++ b/doc/source/sections/configuration/variables.rst
@@ -619,7 +619,7 @@ Variables
      - Whether or not the internal Apache reverse proxy configuration should use HTTPS or not when connecting to the designated JupyterHub service.
    * - JUPYTER_SERVICES_PROXY_CONFIG
      - "{}"
-     - Can be set to add any additional Apache proxy balancer configuration options that should be used when establishing the HTTP(S) connection to the designated JupyterHub service. It is expected to be structured as a string formated dictionary that accepts any key attribute that is supported as an Apache mod_proxy_balancer proxy section option as can be seen at https://httpd.apache.org/docs/2.4/mod/mod_proxy_balancer.html. Therefore a potential config value could be "{'SSLProxyCACertificateFile': 'path/to/local/ca-certificate.pem'}"
+     - Can be set to add any additional Apache proxy balancer configuration options that should be used when establishing the HTTP(S) connection to the designated JupyterHub service. It is expected to be structured as a string formatted dictionary that accepts any key attribute that is supported as an Apache mod_proxy_balancer proxy section option as can be seen at https://httpd.apache.org/docs/2.4/mod/mod_proxy_balancer.html. Therefore a potential config value could be "{'SSLProxyCACertificateFile': 'path/to/local/ca-certificate.pem'}"
    * - JUPYTER_SERVICES_DESC
      - "{}"
      - A text to describe the optional external Jupyter nodes


### PR DESCRIPTION
Adds support for specifying the --jupyter_services_enable_proxy_https and --jupyter_services_proxy_config options as introduced in migrid via https://github.com/ucphhpc/migrid-sync/pull/254