### PR TITLE
Add symlink to automatically find jumphost key in cloud key management command

### DIFF
--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -1396,6 +1396,8 @@ RUN if [ "${ENABLE_CLOUD}" = "True" ]; then \
         [ -n "${CLOUD_JUMPHOST_KEY}" ] || CLOUD_JUMPHOST_KEY="cloud-jumphost-key" ; \ 
         ln -s ../state/secrets/${CLOUD_JUMPHOST_KEY} .ssh/${CLOUD_JUMPHOST_KEY} ; \
         ln -s ../state/secrets/${CLOUD_JUMPHOST_KEY}.pub .ssh/${CLOUD_JUMPHOST_KEY}.pub ; \
+        ln -s .ssh/${CLOUD_JUMPHOST_KEY} .ssh/id_rsa ; \
+        ln -s .ssh/${CLOUD_JUMPHOST_KEY}.pub .ssh/id_rsa.pub ; \
     fi;
 
 # link relevant py trac ini into default location if no TRAC_INI_PATH is set here

--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -1414,6 +1414,8 @@ RUN if [ "${ENABLE_CLOUD}" = "True" ]; then \
         [ -n "${CLOUD_JUMPHOST_KEY}" ] || CLOUD_JUMPHOST_KEY="cloud-jumphost-key" ; \ 
         ln -s ../state/secrets/${CLOUD_JUMPHOST_KEY} .ssh/${CLOUD_JUMPHOST_KEY} ; \
         ln -s ../state/secrets/${CLOUD_JUMPHOST_KEY}.pub .ssh/${CLOUD_JUMPHOST_KEY}.pub ; \
+        ln -s .ssh/${CLOUD_JUMPHOST_KEY} .ssh/id_rsa ; \
+        ln -s .ssh/${CLOUD_JUMPHOST_KEY}.pub .ssh/id_rsa.pub ; \
     fi;
 
 # link relevant py trac ini into default location if no TRAC_INI_PATH is set here

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -1290,6 +1290,8 @@ RUN if [ "${ENABLE_CLOUD}" = "True" ]; then \
         [ -n "${CLOUD_JUMPHOST_KEY}" ] || CLOUD_JUMPHOST_KEY="cloud-jumphost-key" ; \ 
         ln -s ../state/secrets/${CLOUD_JUMPHOST_KEY} .ssh/${CLOUD_JUMPHOST_KEY} ; \
         ln -s ../state/secrets/${CLOUD_JUMPHOST_KEY}.pub .ssh/${CLOUD_JUMPHOST_KEY}.pub ; \
+        ln -s .ssh/${CLOUD_JUMPHOST_KEY} .ssh/id_rsa ; \
+        ln -s .ssh/${CLOUD_JUMPHOST_KEY}.pub .ssh/id_rsa.pub ; \
     fi;
 
 # link relevant py trac ini into default location if no TRAC_INI_PATH is set here


### PR DESCRIPTION
Insert a symlink from the cloud key to a default key name in order to let cloud key management command automatically pick up the correct jumphost key without the need for `.ssh/config`.