### PR TITLE
Ensure the common usage of the OS_CA_CERT_SOURCE_PATH

### DIFF
--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -755,8 +755,9 @@ RUN mkdir -p MiG-certificates \
 USER root
 WORKDIR /tmp
 # Copy in any external certificates that should be part of the OS trusted ca bundle
-COPY external-certificates/ $OS_CA_CERT_SOURCE_PATH/
-RUN update-ca-trust
+RUN update-ca-trust force-enable
+COPY external-certificates/ ${OS_CA_CERT_SOURCE_PATH}/
+RUN update-ca-trust extract
 
 WORKDIR $MIG_ROOT
 USER $USER
@@ -1595,7 +1596,7 @@ RUN mv $WEB_DIR/conf.d/autoindex.conf $WEB_DIR/conf.d/autoindex.conf.disabled \
 
 # Add generated certificate to trust store
 RUN update-ca-trust force-enable \
-    && cp ${CERT_DIR}/combined.pem /etc/pki/ca-trust/source/anchors/ \
+    && cp ${CERT_DIR}/combined.pem ${OS_CA_CERT_SOURCE_PATH}/ \
     && update-ca-trust extract
 
 # rsyslog: Disable systemd and enable /dev/log

--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -771,8 +771,9 @@ RUN mkdir -p MiG-certificates \
 USER root
 WORKDIR /tmp
 # Copy in any external certificates that should be part of the OS trusted ca bundle
-COPY external-certificates/ $OS_CA_CERT_SOURCE_PATH/
-RUN update-ca-trust
+RUN update-ca-trust force-enable
+COPY external-certificates/ ${OS_CA_CERT_SOURCE_PATH}/
+RUN update-ca-trust extract
 
 WORKDIR $MIG_ROOT
 USER $USER
@@ -1619,7 +1620,7 @@ RUN mv $WEB_DIR/conf.d/autoindex.conf $WEB_DIR/conf.d/autoindex.conf.disabled \
 
 # Add generated certificate to trust store
 RUN update-ca-trust force-enable \
-    && cp ${CERT_DIR}/combined.pem /etc/pki/ca-trust/source/anchors/ \
+    && cp ${CERT_DIR}/combined.pem ${OS_CA_CERT_SOURCE_PATH}/ \
     && update-ca-trust extract
 
 # rsyslog: Disable systemd and enable /dev/log

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -728,8 +728,9 @@ RUN mkdir -p MiG-certificates \
 USER root
 WORKDIR /tmp
 # Copy in any external certificates that should be part of the OS trusted ca bundle
-COPY external-certificates/ $OS_CA_CERT_SOURCE_PATH/
-RUN update-ca-trust
+RUN update-ca-trust force-enable
+COPY external-certificates/ ${OS_CA_CERT_SOURCE_PATH}/
+RUN update-ca-trust extract
 
 WORKDIR $MIG_ROOT
 USER $USER
@@ -1493,7 +1494,7 @@ RUN mv $WEB_DIR/conf.d/autoindex.conf $WEB_DIR/conf.d/autoindex.conf.disabled \
 
 # Add generated certificate to trust store
 RUN update-ca-trust force-enable \
-    && cp ${CERT_DIR}/combined.pem /etc/pki/ca-trust/source/anchors/ \
+    && cp ${CERT_DIR}/combined.pem ${OS_CA_CERT_SOURCE_PATH}/ \
     && update-ca-trust extract
 
 # rsyslog: Disable systemd and enable /dev/log


### PR DESCRIPTION
This change aims to fix the issue raised in #98. It also ensures that the OS trust store is correctly updated when external-certificates are copied into the image that is being built