### PR TITLE
Fix typo in the mig-server-extconf*s* volume.

### DIFF
--- a/docker-compose_production.yml
+++ b/docker-compose_production.yml
@@ -876,7 +876,7 @@ volumes:
       device: ${DOCKER_MIGRID_ROOT}/mig
       o: bind
 
-  mig-server-extconf:
+  mig-server-extconfs:
     # Volume used to contain the optional additional mig server config snippets
     driver: local
     driver_opts:


### PR DESCRIPTION
Thanks for pointing it out @ARiis-63 and @Bjarke42 :+1: 
 