### PR TITLE
Adjust paramiko and bcrypt versions

### DIFF
--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -768,7 +768,11 @@ RUN if [ "${UPGRADE_PARAMIKO}" = "True" ]; then \
         #            dependencies specifically into /usr instead.
         #pip3 install -U setuptools; \
         #pip3 install setuptools_rust; \
-        pip3 install --prefix=$(python3-config --prefix) paramiko; \
+        # Additional NOTE: paramiko version 3.0.0 introduces several changes that in particular improves the SFTP download performance.
+        # At the time of writing, the upcoming rhel10 epel uses 3.5, which we use as a version floor for which to use.
+        # However, bcrypt version 4 and above has shown to produce import errors in mod_wsgi caused by the usage of sub-interpreters
+        # as highlighted at https://github.com/PyO3/pyo3/blob/main/guide/src/migration.md#each-pymodule-can-now-only-be-initialized-once-per-process
+        pip3 install --prefix=$(python3-config --prefix) 'paramiko>=3.5' 'bcrypt<4'; \
       fi; \
     fi;
 

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -768,10 +768,19 @@ RUN if [ "${UPGRADE_PARAMIKO}" = "True" ]; then \
         #            dependencies specifically into /usr instead.
         #pip3 install -U setuptools; \
         #pip3 install setuptools_rust; \
-        # Additional NOTE: paramiko version 3.0.0 introduces several changes that in particular improves the SFTP download performance.
-        # At the time of writing, the upcoming rhel10 epel uses 3.5, which we use as a version floor for which to use.
-        # However, bcrypt version 4 and above has shown to produce import errors in mod_wsgi caused by the usage of sub-interpreters
-        # as highlighted at https://github.com/PyO3/pyo3/blob/main/guide/src/migration.md#each-pymodule-can-now-only-be-initialized-once-per-process
+        # Additional NOTE: paramiko version 3.x introduces several changes
+        # that in particular improve the SFTP download performance.
+        # At the time of writing, the RHEL/Rocky 10 EPEL repo provides 3.5,
+        # which we use as a version baseline to mimic.
+        # However, combining that with recent bcrypt versions in the 4.x
+        # series leads to import errors in mod_wsgi caused by the usage of
+        # sub-interpreters as highlighted at
+        # https://github.com/PyO3/pyo3/blob/main/guide/src/migration.md#each-pymodule-can-now-only-be-initialized-once-per-process
+        # with further explanation at
+        # https://bugzilla.redhat.com/show_bug.cgi?id=2255688 and
+        # https://github.com/PyO3/pyo3/issues/3451
+        # So we explicitly cap the bcrypt version to the latest 3.2 one,
+        # which coincides with the default Rocky version, btw.
         pip3 install --prefix=$(python3-config --prefix) 'paramiko>=3.5' 'bcrypt<4'; \
       fi; \
     fi;


### PR DESCRIPTION
Currently the OS default package manager installs paramiko version 2.12.0 with the following instruction when UPGRADE_PARAMIKO is set to False
https://github.com/ucphhpc/docker-migrid/blob/4cb2c075daad5cd2a4eefe864a978b86a3b68029/Dockerfile.rocky9#L419

However, this has shown to produce up to 6 times less SFTP based download bandwidth compared to uploading.
As indicated at https://www.paramiko.org/changelog.html, version 3.0.0 makes several improvements to the SFTP performance, that fixes this imbalance in our benchmarks.

To implement this version fix, it would be as simple as rebuilding the image the UPGRADE_PARAMIKO=True that ensure that the latest paramiko version available at pypi.org is installed via:
https://github.com/ucphhpc/docker-migrid/blob/4cb2c075daad5cd2a4eefe864a978b86a3b68029/Dockerfile.rocky9#L771

This however has shown the side-effect of producing the https://github.com/PyO3/pyo3/blob/main/guide/src/migration.md#each-pymodule-can-now-only-be-initialized-once-per-process import errors by the mod_wsgi process from time to time when importing the paramiko module. This is likely due to mod_wsgi usage of sub-interpreters and the failure to reinitialize the import in a different interpreter after the first initialization.

For the time being, the fix is to limit the bcrypt version to be less than 4.x which Rust implementation seems to introduce this error.