### PR TITLE
Integrate migverifyarchives, migimportdoi, migindexdoi and migacctexpire cron jobs

### DIFF
--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -1594,10 +1594,14 @@ RUN ln -s index-${DOMAIN}.html $MIG_ROOT/state/wwwpublic/index.html && \
 RUN sed -i -e "s@https://ext\.${EMULATE_FQDN}@https://${MIGOID_DOMAIN}@g;s@https://oid\.${EMULATE_FQDN}@https://${EXTOID_DOMAIN}@g;s@https://oidc\.${EMULATE_FQDN}@https://${EXTOIDC_DOMAIN}@g;s@https://${EMULATE_FQDN}@https://${PUBLIC_DOMAIN}@g;s@https://cert\.${EMULATE_FQDN}@https://${EXTCERT_DOMAIN}@g;s@https://sid\.${EMULATE_FQDN}@https://${SID_DOMAIN}@g" $MIG_ROOT/state/wwwpublic/index-${DOMAIN}.html
 
 # Various cron jobs e.g. to clean stale state and inform migoid account users near expiry
-# TODO: add migverifyarchives, migimportdoi, migindexdoi and migsftpmon?
-# TODO: make sure native scripts like migerrors deliver mail outside container
-RUN chmod 755 generated-confs/{migstateclean,mignotifyexpire,migerrors} \
-    && cp generated-confs/{migstateclean,mignotifyexpire,migerrors} /etc/cron.daily/
+RUN chmod 755 generated-confs/{migstateclean,mignotifyexpire,migerrors,migacctexpire} \
+    && cp generated-confs/{migstateclean,mignotifyexpire,migerrors} /etc/cron.daily/ \
+    && cp generated-confs/migacctexpire /etc/cron.monthly/
+RUN if [ "${ENABLE_FREEZE}" = "True" ]; then \
+      chmod 755 generated-confs/{migimportdoi,migindexdoi,migverifyarchives} \
+      && cp generated-confs/{migimportdoi,migindexdoi} /etc/cron.daily/ \
+      && cp generated-confs/migverifyarchives /etc/cron.hourly/ ; \
+    fi;
 
 # Logrotate config if enabled
 RUN if [ "${ENABLE_LOGROTATE}" = "True" ]; then \

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -1481,10 +1481,14 @@ RUN ln -s index-${DOMAIN}.html $MIG_ROOT/state/wwwpublic/index.html && \
 RUN sed -i -e "s@https://ext\.${EMULATE_FQDN}@https://${MIGOID_DOMAIN}@g;s@https://oid\.${EMULATE_FQDN}@https://${EXTOID_DOMAIN}@g;s@https://oidc\.${EMULATE_FQDN}@https://${EXTOIDC_DOMAIN}@g;s@https://${EMULATE_FQDN}@https://${PUBLIC_DOMAIN}@g;s@https://cert\.${EMULATE_FQDN}@https://${EXTCERT_DOMAIN}@g;s@https://sid\.${EMULATE_FQDN}@https://${SID_DOMAIN}@g" $MIG_ROOT/state/wwwpublic/index-${DOMAIN}.html
 
 # Various cron jobs e.g. to clean stale state and inform migoid account users near expiry
-# TODO: add migverifyarchives, migimportdoi, migindexdoi and migsftpmon?
-# TODO: make sure native scripts like migerrors deliver mail outside container
-RUN chmod 755 generated-confs/{migstateclean,mignotifyexpire,migerrors} \
-    && cp generated-confs/{migstateclean,mignotifyexpire,migerrors} /etc/cron.daily/
+RUN chmod 755 generated-confs/{migstateclean,mignotifyexpire,migerrors,migacctexpire} \
+    && cp generated-confs/{migstateclean,mignotifyexpire,migerrors} /etc/cron.daily/ \
+    && cp generated-confs/migacctexpire /etc/cron.monthly/
+RUN if [ "${ENABLE_FREEZE}" = "True" ]; then \
+      chmod 755 generated-confs/{migimportdoi,migindexdoi,migverifyarchives} \
+      && cp generated-confs/{migimportdoi,migindexdoi} /etc/cron.daily/ \
+      && cp generated-confs/migverifyarchives /etc/cron.hourly/ ; \
+    fi;
 
 # Logrotate config if enabled
 RUN if [ "${ENABLE_LOGROTATE}" = "True" ]; then \


### PR DESCRIPTION
Integrate migverifyarchives, migimportdoi, migindexdoi and migacctexpire cron jobs, too. The first three are specific to freeze archives and only added if `ENABLE_FREEZE` is set.