### PR TITLE
Integrate `FREEZE_TO_TAPE` in build

### DIFF
--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -106,6 +106,7 @@ ARG ENABLE_SITESTATUS=True
 ARG STATUS_SYSTEM_MATCH="ANY"
 ARG ENABLE_FREEZE=False
 ARG PERMANENT_FREEZE=""
+ARG FREEZE_TO_TAPE=""
 ARG ENABLE_CRACKLIB=True
 ARG ENABLE_IMNOTIFY=False
 ARG ENABLE_NOTIFY=True
@@ -1098,6 +1099,7 @@ ARG ENABLE_SITESTATUS
 ARG STATUS_SYSTEM_MATCH
 ARG ENABLE_FREEZE
 ARG PERMANENT_FREEZE
+ARG FREEZE_TO_TAPE
 ARG ENABLE_CRACKLIB
 ARG ENABLE_IMNOTIFY
 ARG ENABLE_NOTIFY
@@ -1325,7 +1327,8 @@ RUN ./generateconfs.py --source=. \
     --enable_resources=${ENABLE_RESOURCES} --enable_events=${ENABLE_EVENTS} \
     --enable_gravatars=${ENABLE_GRAVATARS} --enable_sitestatus=${ENABLE_SITESTATUS} \
     --status_system_match="${STATUS_SYSTEM_MATCH}" --enable_freeze=${ENABLE_FREEZE} \
-    --permanent_freeze="${PERMANENT_FREEZE}" --enable_imnotify=${ENABLE_IMNOTIFY} \
+    --permanent_freeze="${PERMANENT_FREEZE}" --freeze_to_tape=${FREEZE_TO_TAPE} \
+    --enable_imnotify=${ENABLE_IMNOTIFY} \
     --enable_cracklib=${ENABLE_CRACKLIB} --enable_twofactor=${ENABLE_TWOFACTOR} \
     --enable_twofactor_strict_address=${ENABLE_TWOFACTOR_STRICT_ADDRESS} \
     --twofactor_auth_apps="${TWOFACTOR_AUTH_APPS}" \

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -107,6 +107,7 @@ ARG ENABLE_SITESTATUS=True
 ARG STATUS_SYSTEM_MATCH="ANY"
 ARG ENABLE_FREEZE=False
 ARG PERMANENT_FREEZE=""
+ARG FREEZE_TO_TAPE=""
 ARG ENABLE_CRACKLIB=True
 ARG ENABLE_IMNOTIFY=False
 ARG ENABLE_NOTIFY=True
@@ -1003,6 +1004,7 @@ ARG ENABLE_SITESTATUS
 ARG STATUS_SYSTEM_MATCH
 ARG ENABLE_FREEZE
 ARG PERMANENT_FREEZE
+ARG FREEZE_TO_TAPE
 ARG ENABLE_CRACKLIB
 ARG ENABLE_IMNOTIFY
 ARG ENABLE_NOTIFY
@@ -1214,7 +1216,8 @@ RUN ./generateconfs.py --source=. \
     --enable_resources=${ENABLE_RESOURCES} --enable_events=${ENABLE_EVENTS} \
     --enable_gravatars=${ENABLE_GRAVATARS} --enable_sitestatus=${ENABLE_SITESTATUS} \
     --status_system_match="${STATUS_SYSTEM_MATCH}" --enable_freeze=${ENABLE_FREEZE} \
-    --permanent_freeze="${PERMANENT_FREEZE}" --enable_imnotify=${ENABLE_IMNOTIFY} \
+    --permanent_freeze="${PERMANENT_FREEZE}" --freeze_to_tape=${FREEZE_TO_TAPE} \
+    --enable_imnotify=${ENABLE_IMNOTIFY} \
     --enable_cracklib=${ENABLE_CRACKLIB} --enable_twofactor=${ENABLE_TWOFACTOR} \
     --enable_twofactor_strict_address=${ENABLE_TWOFACTOR_STRICT_ADDRESS} \
     --twofactor_auth_apps="${TWOFACTOR_AUTH_APPS}" \

--- a/Makefile
+++ b/Makefile
@@ -277,7 +277,7 @@ wipesitedatawarning:
 # Test that all defined env variables are properly documented
 test-doc:
 	@shopt -s extglob; \
-	for i in $$( grep -hv '\(^#.*\|^$$\)' !(migrid-httpd).env | sed -E 's!^([^=]*)=.*$$!\1!g' | sort | uniq ) ; do \
+	for i in $$( grep -hv '\(^#.*\|^$$\)' --exclude=migrid-httpd.env *.env | sed -E 's!^([^=]*)=.*$$!\1!g' | sort | uniq ) ; do \
 		grep -q "$$i" doc/source/sections/configuration/variables.rst \
 		|| missing+=( "$$i" ) ; \
 	done; \

--- a/doc/source/sections/configuration/variables.rst
+++ b/doc/source/sections/configuration/variables.rst
@@ -395,6 +395,9 @@ Variables
    * - PERMANENT_FREEZE
      - 
      - Flavors of frozen archives to write-protect when user selects finalize.
+   * - FREEZE_TO_TAPE
+     - 
+     - If `PERMANENT_FREEZE` is set this value is the expected time before such finalized freeze archives are stored on tape.
    * - ENABLE_CRACKLIB
      - True
      - Enable the built-in cracklib password checking integration on user-supplied passwords


### PR DESCRIPTION
Integrate `FREEZE_TO_TAPE` so that it can in fact be used with `migverifyarchives` cronjob as well as on show Archive page. Adjusted `Makefile` test-doc target to avoid the `!(migrid-http).env` construct which just fails here.
Documented `FREEZE_TO_TAPE` option in conf variables.