### PR TITLE
Integrate freeze_tape in persistent state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,8 @@ initdirs: initcomposevars
 	mkdir -p ${VOLATILE_ROOT}/mig_system_run
 	mkdir -p ${VOLATILE_ROOT}/openid_store
 	mkdir -p ${PERSISTENT_ROOT}/freeze_home
+	# NOTE: staging subdir is needed by migverifyarchives cronjob
+	mkdir -p ${PERSISTENT_ROOT}/freeze_tape/staging
 	mkdir -p ${PERSISTENT_ROOT}/mrsl_files
 	mkdir -p ${PERSISTENT_ROOT}/resource_home
 	mkdir -p ${PERSISTENT_ROOT}/re_home

--- a/docker-compose_production.yml
+++ b/docker-compose_production.yml
@@ -128,6 +128,9 @@ services:
         source: freeze_home
         target: /home/mig/state/freeze_home
       - type: volume
+        source: freeze_tape
+        target: /home/mig/state/freeze_tape
+      - type: volume
         source: mrsl_files
         target: /home/mig/state/mrsl_files
       - type: volume
@@ -273,6 +276,9 @@ services:
       #  source: freeze_home
       #  target: /home/mig/state/freeze_home
       #- type: volume
+      #  source: freeze_tape
+      #  target: /home/mig/state/freeze_tape
+      #- type: volume
       #  source: mrsl_files
       #  target: /home/mig/state/mrsl_files
       #- type: volume
@@ -413,6 +419,9 @@ services:
       #  source: freeze_home
       #  target: /home/mig/state/freeze_home
       #- type: volume
+      #  source: freeze_tape
+      #  target: /home/mig/state/freeze_tape
+      #- type: volume
       #  source: mrsl_files
       #  target: /home/mig/state/mrsl_files
       #- type: volume
@@ -552,6 +561,9 @@ services:
       #  source: freeze_home
       #  target: /home/mig/state/freeze_home
       #- type: volume
+      #  source: freeze_tape
+      #  target: /home/mig/state/freeze_tape
+      #- type: volume
       #  source: mrsl_files
       #  target: /home/mig/state/mrsl_files
       #- type: volume
@@ -690,6 +702,9 @@ services:
       #- type: volume
       #  source: freeze_home
       #  target: /home/mig/state/freeze_home
+      #- type: volume
+      #  source: freeze_tape
+      #  target: /home/mig/state/freeze_tape
       #- type: volume
       #  source: mrsl_files
       #  target: /home/mig/state/mrsl_files
@@ -930,6 +945,14 @@ volumes:
     driver_opts:
       type: none
       device: ${PERSISTENT_ROOT}/freeze_home
+      o: bind
+
+  freeze_tape:
+    # Volume used to contain the migrid freeze_tape
+    driver: local
+    driver_opts:
+      type: none
+      device: ${PERSISTENT_ROOT}/freeze_tape
       o: bind
 
   mrsl_files:


### PR DESCRIPTION
Add the freeze_tape state dir with staging subdir to integrate archive taping where deployments want it. Requires explicit configuration of freeze and tape variables to do anything.