### PR TITLE
Cleanup after pylustrequota build

### DIFF
--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -1705,6 +1705,7 @@ RUN if [ "${ENABLE_QUOTA}" = "True" ] \
             && make liblustreapi.la \
             && cd ${MIG_ROOT}/mig/src/pylustrequota \
             && python3 setup.py install; \
+            && rm -rf ${MIG_ROOT}/mig/src/pylustrequota/lustre-release \
         fi; \
     fi;
 #------------------------- next stage -----------------------------#

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -1592,6 +1592,7 @@ RUN if [ "${ENABLE_QUOTA}" = "True" ] \
             && make liblustreapi.la \
             && cd ${MIG_ROOT}/mig/src/pylustrequota \
             && python3 setup.py install; \
+            && rm -rf ${MIG_ROOT}/mig/src/pylustrequota/lustre-release \
         fi; \
     fi;
 #------------------------- next stage -----------------------------#


### PR DESCRIPTION
Cleanup lustre source code after pylustrequota build since it's not needed and just consumes space in the image.