### PR TITLE
Use new `make patch` from migrid PR320 to patch installed paramiko.

### DIFF
--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -1498,6 +1498,10 @@ RUN cp generated-confs/libnss_mig.conf /etc/ \
     #&& cp /etc/nsswitch.conf /etc/nsswitch.conf.backup
     && cp generated-confs/nsswitch.conf /etc/
 
+# Adjust paramiko to reduce log noise from scans if matching patch is available
+RUN cd $MIG_ROOT/mig/src/paramiko \
+    && make patch PLATFORM=el8
+
 RUN chmod 755 generated-confs/envvars \
     && chmod 755 generated-confs/httpd.conf
 

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -1385,6 +1385,10 @@ RUN cp generated-confs/libnss_mig.conf /etc/ \
     #&& cp /etc/nsswitch.conf /etc/nsswitch.conf.backup
     && cp generated-confs/nsswitch.conf /etc/
 
+# Adjust paramiko to reduce log noise from scans if matching patch is available
+RUN cd $MIG_ROOT/mig/src/paramiko \
+    && make patch PLATFORM=el9
+
 RUN chmod 755 generated-confs/envvars \
     && chmod 755 generated-confs/httpd.conf
 


### PR DESCRIPTION
In order to prevent the rather verbose python tracebacks in the logs from common ssh/sftp scans to end up in our log monitoring. 