### PR TITLE
lustrequota: Use github mirror for fetching lustre source code

### DIFF
--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -1693,7 +1693,6 @@ RUN if [ "${ENABLE_QUOTA}" = "True" ] \
             krb5-devel.x86_64 \
             && dnf clean all \
             && rm -fr /var/cache/dnf \
-            # TODO: clean up after this download+build to avoid bloating image
             && cd ${MIG_ROOT}/mig/src/pylustrequota \
             && git clone https://github.com/lustre/lustre-release \
             && cd ${MIG_ROOT}/mig/src/pylustrequota/lustre-release \

--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -1695,7 +1695,7 @@ RUN if [ "${ENABLE_QUOTA}" = "True" ] \
             && rm -fr /var/cache/dnf \
             # TODO: clean up after this download+build to avoid bloating image
             && cd ${MIG_ROOT}/mig/src/pylustrequota \
-            && git clone git://git.whamcloud.com/fs/lustre-release.git \
+            && git clone https://github.com/lustre/lustre-release \
             && cd ${MIG_ROOT}/mig/src/pylustrequota/lustre-release \
             && git checkout ${QUOTA_LUSTRE_VERSION} \
             && sh ./autogen.sh \

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -1580,7 +1580,6 @@ RUN if [ "${ENABLE_QUOTA}" = "True" ] \
             krb5-devel.x86_64 \
             && dnf clean all \
             && rm -fr /var/cache/dnf \
-            # TODO: clean up after this download+build to avoid bloating image
             && cd ${MIG_ROOT}/mig/src/pylustrequota \
             && git clone https://github.com/lustre/lustre-release \
             && cd ${MIG_ROOT}/mig/src/pylustrequota/lustre-release \

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -1582,7 +1582,7 @@ RUN if [ "${ENABLE_QUOTA}" = "True" ] \
             && rm -fr /var/cache/dnf \
             # TODO: clean up after this download+build to avoid bloating image
             && cd ${MIG_ROOT}/mig/src/pylustrequota \
-            && git clone git://git.whamcloud.com/fs/lustre-release.git \
+            && git clone https://github.com/lustre/lustre-release \
             && cd ${MIG_ROOT}/mig/src/pylustrequota/lustre-release \
             && git checkout ${QUOTA_LUSTRE_VERSION} \
             && sh ./autogen.sh \


### PR DESCRIPTION
git access (port 9418) to git://git.whamcloud.com/fs/lustre-release.git has been blocked for over two weeks now[1], therefore we have to switch to the github mirror[2]
[1]
==================================================================================
$> > nmap -p 9418 git.whamcloud.com
Starting Nmap 7.97 ( https://nmap.org ) at 2025-08-26 16:57 +0200
Nmap scan report for git.whamcloud.com (104.21.48.246)
Host is up (0.0055s latency).
Other addresses for git.whamcloud.com (not scanned): 2606:4700:3030::ac43:8af5 2606:4700:3031::6815:30f6 172.67.138.245

PORT     STATE    SERVICE
9418/tcp filtered git

Nmap done: 1 IP address (1 host up) scanned in 0.76 seconds
==================================================================================
[2] https://github.com/lustre/lustre-release