### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: Continuous Integration
+permissions:
+  contents: read
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/ucphhpc/docker-migrid/security/code-scanning/2](https://github.com/ucphhpc/docker-migrid/security/code-scanning/2)

To fix the issue, explicitly restrict the GITHUB_TOKEN permissions used by this workflow to the least privilege necessary. This workflow only checks out code and runs local build/test commands; it does not interact with issues, pull requests, or perform any write operations via the GitHub API. Therefore, setting `contents: read` at the workflow or job level is sufficient and appropriate.

The best minimal fix without changing existing behavior is:

- Add a `permissions` block at the top level of the workflow (alongside `name` and `on`) so it applies to all jobs that don’t override it.
- Set `contents: read` there. No other scopes appear necessary given the current steps.

Concretely, in `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `name: Continuous Integration` line and the `on:` block (e.g., new line 2 and 3). No imports or additional methods are needed because this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
