### PR TITLE
Restrict spellcheck action to explicit read-only access to repo

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,4 +1,7 @@
 name: Spell Checking
+# No need for more than read permission
+permissions:
+  contents: read
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   pull_request:


### PR DESCRIPTION
Restrict spellcheck action to explicit read-only access to repo as recommended by code scanner.
NB: this is already the repo default setting.