### PR TITLE
Just use the now default wsgidav-3.x+ version of the webdavs service

### DIFF
--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -923,11 +923,6 @@ RUN if [ "$WITH_GIT" = "True" ]; then \
 	echo "migrid version: ${MIG_SVN_REPO} trunk ${MIG_SVN_REV}" > ./active-migrid-version.txt; \
     fi;
 
-# NOTE: we manually need to enable modern grid_webdavs.py here for now.
-#       Replace any existing symlink with one to the 3.x script.
-RUN rm -f ${MIG_ROOT}/mig/server/grid_webdavs.py ; \
-    ln -s grid_webdavs-3.x.py ${MIG_ROOT}/mig/server/grid_webdavs.py;
-
 
 #------------------------- next stage -----------------------------#
 FROM --platform=linux/$ARCH download_mig AS install_mig


### PR DESCRIPTION
Also drop the tiny adjustment to link in the wsgidav-3.x+ version of the webdavs service here after merging https://github.com/ucphhpc/migrid-sync/pull/504 .