### PR TITLE
Retire outdated svn build support

### DIFF
--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -205,7 +205,6 @@ ARG DATASAFETY_LINK=""
 ARG DATASAFETY_TEXT=""
 # NOTE: no python2 here and we already get 4.3+ for python3
 ARG MODERN_WSGIDAV=False
-ARG WITH_GIT=False
 ARG OPENSSH_VERSION=7.4
 ARG VGRID_LABEL=VGrid
 ARG DIGEST_SALT="AUTO"
@@ -278,7 +277,6 @@ ARG OPENID_PORT
 ARG WITH_PY3
 ARG JUPYTER_SERVICES
 ARG CLOUD_SERVICES
-#ARG WITH_GIT
 
 RUN echo "*** BEGIN Build variables ***" && \
     echo "UID and GID: $UID $GID" && \
@@ -292,8 +290,8 @@ RUN echo "*** BEGIN Build variables ***" && \
     "${MIGCERT_HTTPS_PORT} ${EXTCERT_HTTPS_PORT}" \
     "${SID_HTTPS_PORT} ${SFTP_PORT} ${SFTP_SUBSYS_PORT}" \
     "${FTPS_CTRL_PORT} ${DAVS_PORT} ${OPENID_PORT}" && \
-    echo "Enable git checkout & repo : $WITH_GIT $MIG_GIT_REPO" && \
-    echo "MiG git branch & revision:  $MIG_GIT_BRANCH $MIG_GIT_REV" && \
+    echo "MiG git repo: $MIG_GIT_REPO" && \
+    echo "MiG git branch & revision: $MIG_GIT_BRANCH $MIG_GIT_REV" && \
     echo "Emulate flavor & fqdn: $EMULATE_FLAVOR $EMULATE_FQDN" && \
     echo "Enable python3 support: $WITH_PY3" && \
     #echo "Designated jupyter services: $JUPYTER_SERVICES" && \
@@ -891,7 +889,6 @@ RUN if [ "${WITH_PY3}" = "True" ]; then \
 FROM --platform=linux/$ARCH mig_dependencies AS download_mig
 LABEL MIGRID=true
 ARG DOMAIN
-ARG WITH_GIT
 ARG MIG_GIT_REPO
 ARG MIG_GIT_BRANCH
 ARG MIG_GIT_REV
@@ -1353,7 +1350,6 @@ ARG PREFER_PYTHON3
 ARG ENABLE_LOGROTATE
 ARG LOGROTATE_MIGRID
 ARG ENABLE_GDP
-ARG WITH_GIT
 ARG MIG_GIT_BRANCH
 ARG ENABLE_QUOTA
 ARG ENABLE_FREEZE
@@ -1566,8 +1562,7 @@ RUN if [ "${ENABLE_GDP}" = "True" ]; then \
 # Install lustreclient
 # NOTE: Requires py3 and git next branch
 RUN if [ "${ENABLE_QUOTA}" = "True" ] \
-            && [ "${PREFER_PYTHON3}" = "True" ] \
-            && [ "${WITH_GIT}" = "True" ]; then \
+            && [ "${PREFER_PYTHON3}" = "True" ]; then \
         if [ "${QUOTA_BACKEND}" = "lustre" ] \
             || [ "${QUOTA_BACKEND}" = "lustre-gocryptfs" ]; then \
             echo "install python lustreclient extensions" \

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -1,7 +1,7 @@
 # Default ARG values which may be overriden in build command with
 # docker-compose build --build-arg KEY=VAL
 #  as in 
-# make init && make build ARGS="--build-arg MIG_SVN_REV=HEAD"
+# make init && make build ARGS="--build-arg MIG_GIT_REV=HEAD"
 #  or using
 # docker-compose build
 # with .env file in place
@@ -56,8 +56,6 @@ ARG FTPS_CTRL_PORT=8021
 ARG FTPS_CTRL_SHOW_PORT=21
 ARG OPENID_PORT=8443
 ARG OPENID_SHOW_PORT=443
-ARG MIG_SVN_REPO=https://svn.code.sf.net/p/migrid/code/trunk
-ARG MIG_SVN_REV=HEAD
 ARG MIG_GIT_REPO=https://github.com/ucphhpc/migrid-sync.git
 # NOTE: next branch is needed for python3 support
 ARG MIG_GIT_BRANCH=next
@@ -196,7 +194,7 @@ ARG IMNOTIFY_ADDRESS=""
 ARG IMNOTIFY_CHANNEL=""
 ARG IMNOTIFY_USERNAME=""
 ARG IMNOTIFY_PASSWD=""
-ARG EXTERNAL_DOC="https://sourceforge.net/p/migrid/wiki"
+ARG EXTERNAL_DOC="https://github.com/ucphhpc/migrid-sync/wiki"
 ARG IO_ACCOUNT_EXPIRE="False"
 # TODO: expose and enable these UI vars
 #ARG PEERS_NOTICE=""
@@ -272,8 +270,6 @@ ARG SFTP_SUBSYS_PORT
 ARG DAVS_PORT
 ARG FTPS_CTRL_PORT
 ARG OPENID_PORT
-#ARG MIG_SVN_REPO
-#ARG MIG_SVN_REV
 #ARG MIG_GIT_REPO
 #ARG MIG_GIT_BRANCH
 #ARG MIG_GIT_REV
@@ -296,7 +292,6 @@ RUN echo "*** BEGIN Build variables ***" && \
     "${MIGCERT_HTTPS_PORT} ${EXTCERT_HTTPS_PORT}" \
     "${SID_HTTPS_PORT} ${SFTP_PORT} ${SFTP_SUBSYS_PORT}" \
     "${FTPS_CTRL_PORT} ${DAVS_PORT} ${OPENID_PORT}" && \
-    #echo "MiG svn repo and revision: $MIG_SVN_REPO $MIG_SVN_REV" && \
     echo "Enable git checkout & repo : $WITH_GIT $MIG_GIT_REPO" && \
     echo "MiG git branch & revision:  $MIG_GIT_BRANCH $MIG_GIT_REV" && \
     echo "Emulate flavor & fqdn: $EMULATE_FLAVOR $EMULATE_FQDN" && \
@@ -364,6 +359,7 @@ RUN dnf update -y \
     mod_auth_openidc \
     tzdata \
     initscripts \
+    # NOTE: svn is still needed for trac plugin install from svn+https
     svn \
     git \
     vim \
@@ -895,8 +891,6 @@ RUN if [ "${WITH_PY3}" = "True" ]; then \
 FROM --platform=linux/$ARCH mig_dependencies AS download_mig
 LABEL MIGRID=true
 ARG DOMAIN
-ARG MIG_SVN_REPO
-ARG MIG_SVN_REV
 ARG WITH_GIT
 ARG MIG_GIT_REPO
 ARG MIG_GIT_BRANCH
@@ -910,18 +904,13 @@ USER $USER
 # Install and configure MiG
 # NOTE: git refuses to clone into non-empty dir - use tmp
 
-RUN if [ "$WITH_GIT" = "True" ]; then \
-      git clone ${MIG_GIT_REPO} migrid.git && \
-        cd migrid.git && \
-        git checkout -B ${MIG_GIT_BRANCH} --track origin/${MIG_GIT_BRANCH} && \
-        git checkout ${MIG_GIT_REV} && cd .. && \
-        rsync -a migrid.git/ ./ && \
-        rm -rf migrid.git/ && \
-	echo "migrid version: ${MIG_GIT_REPO} ${MIG_GIT_BRANCH} ${MIG_GIT_REV}" > ./active-migrid-version.txt; \
-    else \
-      svn checkout -r ${MIG_SVN_REV} ${MIG_SVN_REPO} . && \
-	echo "migrid version: ${MIG_SVN_REPO} trunk ${MIG_SVN_REV}" > ./active-migrid-version.txt; \
-    fi;
+RUN git clone ${MIG_GIT_REPO} migrid.git && \
+    cd migrid.git && \
+    git checkout -B ${MIG_GIT_BRANCH} --track origin/${MIG_GIT_BRANCH} && \
+    git checkout ${MIG_GIT_REV} && cd .. && \
+    rsync -a migrid.git/ ./ && \
+    rm -rf migrid.git/ && \
+    echo "migrid version: ${MIG_GIT_REPO} ${MIG_GIT_BRANCH} ${MIG_GIT_REV}" > ./active-migrid-version.txt
 
 
 #------------------------- next stage -----------------------------#

--- a/development.env
+++ b/development.env
@@ -209,10 +209,6 @@ OPENID_STORE=${DOCKER_MIGRID_ROOT}/state/openid_store
 # directory and the underlying location can be configured here.
 VGRID_FILES_WRITABLE=${DOCKER_MIGRID_ROOT}/state/vgrid_files_writable
 
-# Which svn repo and version of migrid should be used
-#MIG_SVN_REPO=https://svn.code.sf.net/p/migrid/code/trunk
-#MIG_SVN_REV=HEAD
-
 # Which git repo and version of migrid should be used
 MIG_GIT_REPO=https://github.com/ucphhpc/migrid-sync.git
 # NOTE: use 'git next' here for the supported python3 version
@@ -229,9 +225,6 @@ CONTAINER_TAG=":latest"
 #       will not switch it on. Use PREFER_PYTHON3 as well to do that.
 # NOTE: leave the python3 inclusion to the Dockerfile default here
 #WITH_PY3=True
-
-# Toggle git support - effectively switches from SVN to GIT options above
-WITH_GIT=True
 
 # Which timezone should the service use
 TZ=Europe/Copenhagen

--- a/development_gdp.env
+++ b/development_gdp.env
@@ -210,10 +210,6 @@ OPENID_STORE=${DOCKER_MIGRID_ROOT}/state/openid_store
 # directory and the underlying location can be configured here.
 VGRID_FILES_WRITABLE=${DOCKER_MIGRID_ROOT}/state/vgrid_files_writable
 
-# Which svn repo and version of migrid should be used
-#MIG_SVN_REPO=https://svn.code.sf.net/p/migrid/code/trunk
-#MIG_SVN_REV=HEAD
-
 # Which git repo and version of migrid should be used
 MIG_GIT_REPO=https://github.com/ucphhpc/migrid-sync.git
 # NOTE: use 'git next' here for the supported python3 version
@@ -230,9 +226,6 @@ CONTAINER_TAG=":latest"
 #       will not switch it on. Use PREFER_PYTHON3 as well to do that.
 # NOTE: leave the python3 inclusion to the Dockerfile default here
 #WITH_PY3=True
-
-# Toggle git support - effectively switches from SVN to GIT options above
-WITH_GIT=True
 
 # Which timezone should the service use
 TZ=Europe/Copenhagen

--- a/doc/source/sections/configuration/variables.rst
+++ b/doc/source/sections/configuration/variables.rst
@@ -247,21 +247,15 @@ Variables
    * - OPENID_SHOW_PORT
      - 443
      - Where the OpenID service is advertized to run for the users. Mainly used when the standard openid port 443 is transparently forwarded in the local firewall or Apache proxy.
-   * - MIG_SVN_REPO
-     - https://svn.code.sf.net/p/migrid/code/trunk
-     - The Subversion repository from which the migrid code will be pulled, if Git isn't specifically requested (i.e. unless WITH_GIT=True) 
-   * - MIG_SVN_REV
-     - HEAD
-     - Which SVN revision of the migrid codebase to deploy from the above repo when SVN is used
    * - MIG_GIT_REPO
      - https://github.com/ucphhpc/migrid-sync.git
-     - The Git repository from which the migrid code will be pulled, if Git is requested (i.e. WITH_GIT=True)
+     - The Git repository from which the migrid code will be pulled
    * - MIG_GIT_BRANCH
      - main
-     - The Git branch which should be used when migrid source code is pulled. Typically `main` (formerly `edge`) or `next` (formerly `experimental`).
+     - The Git branch which should be used when migrid source code is pulled. Typically `next` (formerly `experimental`).
    * - MIG_GIT_REV
      - HEAD
-     - The Git revision which should be used when migrid source code is pulled.
+     - The Git revision of the migrid source code to use.
    * - SUPPORT_EMAIL
      - mig
      - The email address to point users to for various support purposes in the migrid user pages
@@ -560,9 +554,6 @@ Variables
    * - MODERN_WSGIDAV
      - False
      - Whether the WebDAVS service should use the tried and tested wsgidav 1.3 or upgrade to a more modern version.
-   * - WITH_GIT
-     - False
-     - Use git instead of subversion, see `$MIG_GIT_REPO`
    * - OPENSSH_VERSION
      - 7.4
      - Minimum client OpenSSH version to support, mainly regarding security hardening

--- a/production.env
+++ b/production.env
@@ -215,10 +215,6 @@ OPENID_STORE=${VOLATILE_ROOT}/openid_store
 #VGRID_FILES_WRITABLE=/storage/netfs/vgrid_files_writable
 VGRID_FILES_WRITABLE=${PERSISTENT_ROOT}/vgrid_files_writable
 
-# Which svn repo and version of migrid should be used
-#MIG_SVN_REPO=https://svn.code.sf.net/p/migrid/code/trunk
-#MIG_SVN_REV=HEAD
-
 # Which git repo and version of migrid should be used
 MIG_GIT_REPO=https://github.com/ucphhpc/migrid-sync.git
 # NOTE: use 'git next' here for the supported python3 version
@@ -235,9 +231,6 @@ CONTAINER_TAG=":latest"
 #       will not switch it on. Use PREFER_PYTHON3 as well to do that.
 # NOTE: leave the python3 inclusion to the Dockerfile default here
 #WITH_PY3=True
-
-# Toggle git support - effectively switches from SVN to GIT options above
-WITH_GIT=True
 
 # Which timezone should the service use
 TZ=Europe/Copenhagen


### PR DESCRIPTION
Retire support for the no longer available migrid subversion repo from sourceforge. Also retires the `WITH_GIT` variable as it is now the default.