### PR TITLE
Upgrade the apache mod auth openidc module

### DIFF
--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -540,7 +540,7 @@ RUN echo "UPGRADE_MOD_AUTH_OPENIDC: $UPGRADE_MOD_AUTH_OPENIDC"
 RUN if [ "$UPGRADE_MOD_AUTH_OPENIDC" = "True" ]; then \
         if [ -z "${UPGRADE_OIDC_AUTH_MOD_SRC}" ]; then \
 		echo "upgrading mod_auth_openidc from upstream release package"; \
-		UPGRADE_OIDC_AUTH_MOD_SRC="https://github.com/OpenIDC/mod_auth_openidc/releases/download/v2.4.19/mod_auth_openidc-2.4.19-1.el9.x86_64.rpm"; \
+		UPGRADE_OIDC_AUTH_MOD_SRC="https://github.com/OpenIDC/mod_auth_openidc/releases/download/v2.4.19.3/mod_auth_openidc-2.4.19.3-1.el9.x86_64.rpm"; \
 	else \
 		echo "upgrading mod_auth_openidc from ${UPGRADE_OIDC_AUTH_MOD_SRC}"; \
 	fi; \ 


### PR DESCRIPTION
Upgrade the apache mod auth openidc module to pull in the latest bug and security fixes announced upstream
https://github.com/OpenIDC/mod_auth_openidc/releases/tag/v2.4.19.3