### PR TITLE
Integrate linting of `Dockerfile` with `hadolint` and shuffle hadolint and trivy make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all init initservices initbuild initdirs initcomposevars
-.PHONY: dockerbuild dockerlint dockerpush
+.PHONY: dockerbuild dockerlint dockersecscanimg dockerpush
 .PHONY: dockerclean dockervolumeclean
 .PHONY: wipesitestatewarning wipesitedatawarning
 .PHONY: clean distclean sitestateclean sitedataclean
@@ -210,8 +210,24 @@ dockerbuild: init
 	${DOCKER_COMPOSE} ${DOCKER_COMPOSE_BUILD_ARGS} build ${BUILD_ARGS}
 
 dockerlint:
+	@if [ -e Dockerfile ]; then \
+		echo "Linting Dockerfile with hadolint"; \
+		HADOLINT="$$(command -v hadolint || true)"; \
+		HADOLINT_ARGS=""; \
+		if [ -x "$${HADOLINT}" ]; then \
+			#echo "Scanning Dockerfile with native $${HADOLINT} $${HADOLINT_ARGS}"; \
+			$${HADOLINT} $${HADOLINT_ARGS} < Dockerfile; \
+		else \
+			#echo "Scanning Dockerfile with ${DOCKER} wrapped hadolint $${HADOLINT_ARGS}"; \
+			${DOCKER} run --rm -i ghcr.io/hadolint/hadolint $${HADOLINT_ARGS} < Dockerfile; \
+		fi; \
+	else \
+		echo "No Dockerfile to scan with hadolint - did you make init?"; \
+	fi
+
+dockersecscanimg:
 	@if [[ "$$(${DOCKER} image ls -q ${CONTAINER_REGISTRY}/${OWNER}/${IMAGE})" != "" ]]; then \
-		echo "Linting and security scanning ${IMAGE} image with trivy"; \
+		echo "Security scanning ${IMAGE} image with trivy"; \
 		TRIVY="$$(command -v trivy || true)"; \
 		TRIVY_ARGS="--scanners vuln"; \
 		if [[ $$(basename "${DOCKER}") == "podman" ]]; then \
@@ -230,12 +246,12 @@ dockerlint:
 			FWD_DOCKER_SOCK="-v /var/run/docker.sock:/var/run/docker.sock"; \
 		fi; \
 		if [ -x "$${TRIVY}" ]; then \
-			#echo "Scanning ${IMAGE} image with $${TRIVY} $${TRIVY_ARGS}"; \
+			#echo "Scanning ${IMAGE} image with native $${TRIVY} $${TRIVY_ARGS}"; \
 			$${TRIVY} image $${TRIVY_ARGS} "${CONTAINER_REGISTRY}/${OWNER}/${IMAGE}${CONTAINER_TAG}"; \
 		else \
-			#echo "Scanning ${IMAGE} image with docker trivy $${TRIVY_ARGS}"; \
+			#echo "Scanning ${IMAGE} image with ${DOCKER} wrapped trivy $${TRIVY_ARGS}"; \
 			mkdir -p cache/trivy; \
-			${DOCKER} run $${FWD_DOCKER_SOCK} -v ${DOCKER_MIGRID_ROOT}/cache/trivy:/root/.cache/ aquasec/trivy image $${TRIVY_ARGS} "${CONTAINER_REGISTRY}/${OWNER}/${IMAGE}${CONTAINER_TAG}"; \
+			${DOCKER} run --rm -i $${FWD_DOCKER_SOCK} -v ${DOCKER_MIGRID_ROOT}/cache/trivy:/root/.cache/ aquasec/trivy image $${TRIVY_ARGS} "${CONTAINER_REGISTRY}/${OWNER}/${IMAGE}${CONTAINER_TAG}"; \
 		fi; \
 	else \
 		echo "No ${IMAGE} images to scan with trivy - did you build?"; \


### PR DESCRIPTION
Add linting of `Dockerfile` with `hadolint` and adjust make targets to be:
`make dockerlint`
for `hadolint` scan and
`make dockersecscanimg`
for the existing image security scan with `trivy`.
Polish output slightly.

Don't forget to adjust image security scan cron jobs to use the new `dockersecscanimg` target once merged.