### PR TITLE
Drop the last remainder of the `prefer_python3` option with PR603 merged upstream

### DIFF
--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -1212,7 +1212,6 @@ RUN ./generateconfs.py --source=. \
     --jupyter_services_desc="${JUPYTER_SERVICES_DESC}" \
     --cloud_services="${CLOUD_SERVICES}" \
     --cloud_services_desc="${CLOUD_SERVICES_DESC}" \
-    --prefer_python3=True \
     --user_clause=User --group_clause=Group \
     --listen_clause='#Listen' \
     --serveralias_clause='ServerAlias' --alias_field=email \


### PR DESCRIPTION
Follow-up to #167 to remove last `prefer_python3` reference now that the option is no longer supported upstream since the merge of
https://github.com/ucphhpc/migrid-sync/pull/603