### PR TITLE
Rocky10 support again - testing only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        container_os: [rocky9]
+        container_os: [rocky9, rocky10]
         environment_profile: [development]
     steps:
       - name: Check out repository contents

--- a/Dockerfile.rocky10
+++ b/Dockerfile.rocky10
@@ -1,0 +1,1658 @@
+# Default ARG values which may be overriden in build command with
+# docker-compose build --build-arg KEY=VAL
+#  as in 
+# make init && make build ARGS="--build-arg MIG_SVN_REV=HEAD"
+#  or using
+# docker-compose build
+# with .env file in place
+#
+# IMPORTANT: all ARGS here that should allow being overriden from .env MUST be
+#            explicitly listed in docker-compose.yml *args* list, too.
+#            Furthermore they must be declared after FROM in each stage used.
+
+ARG DOCKER_MIGRID_ROOT=.
+ARG ARCH=amd64
+ARG UID=1000
+ARG GID=1000
+ARG DOMAIN=migrid.test
+ARG WILDCARD_DOMAIN=*.migrid.test
+ARG PUBLIC_DOMAIN=www.migrid.test
+ARG PUBLIC_ALIAS_DOMAIN=
+ARG STATUS_ALIAS_DOMAIN=
+ARG PUBLIC_SEC_DOMAIN=
+ARG MIGCERT_DOMAIN=cert.migrid.test
+ARG EXTCERT_DOMAIN=
+ARG MIGOID_DOMAIN=ext.migrid.test
+ARG EXTOID_DOMAIN=
+ARG EXTOIDC_DOMAIN=
+ARG SID_DOMAIN=sid.migrid.test
+ARG IO_DOMAIN=io.migrid.test
+ARG OPENID_DOMAIN=openid.migrid.test
+ARG FTPS_DOMAIN=ftps.migrid.test
+ARG SFTP_DOMAIN=sftp.migrid.test
+ARG WEBDAVS_DOMAIN=webdavs.migrid.test
+ARG MIG_OID_PROVIDER=https://ext.migrid.test/openid/
+ARG EXT_OID_PROVIDER=unset
+ARG EXT_OIDC_PROVIDER_META_URL=unset
+ARG EXT_OIDC_CLIENT_NAME=unset
+ARG EXT_OIDC_CLIENT_ID=unset
+ARG EXT_OIDC_SCOPE=unset
+ARG EXT_OIDC_REMOTE_USER_CLAIM=unset
+ARG EXT_OIDC_PASS_CLAIM_AS=unset
+ARG PUBLIC_HTTP_PORT=80
+ARG PUBLIC_HTTPS_PORT=444
+ARG MIGCERT_HTTPS_PORT=446
+ARG EXTCERT_HTTPS_PORT=447
+ARG MIGOID_HTTPS_PORT=443
+ARG EXTOID_HTTPS_PORT=445
+ARG EXTOIDC_HTTPS_PORT=449
+ARG SID_HTTPS_PORT=448
+ARG SFTP_SUBSYS_PORT=22222
+ARG SFTP_PORT=2222
+ARG SFTP_SHOW_PORT=22
+ARG DAVS_PORT=4443
+ARG DAVS_SHOW_PORT=443
+ARG FTPS_CTRL_PORT=8021
+ARG FTPS_CTRL_SHOW_PORT=21
+ARG OPENID_PORT=8443
+ARG OPENID_SHOW_PORT=443
+ARG MIG_SVN_REPO=https://svn.code.sf.net/p/migrid/code/trunk
+ARG MIG_SVN_REV=HEAD
+ARG MIG_GIT_REPO=https://github.com/ucphhpc/migrid-sync.git
+# NOTE: next branch is needed for python3 support
+ARG MIG_GIT_BRANCH=next
+ARG MIG_GIT_REV=HEAD
+ARG ADMIN_EMAIL=mig
+ARG ADMIN_LIST=
+ARG SUPPORT_EMAIL=mig
+ARG SMTP_SENDER=
+ARG SMTP_SERVER=localhost
+ARG SMTP_PORT=25
+ARG LOG_LEVEL=info
+ARG TITLE="Minimum intrusion Grid"
+ARG SHORT_TITLE=MiG
+ARG MIG_OID_TITLE=MiG
+ARG EXT_OID_TITLE=External
+ARG PEERS_PERMIT="distinguished_name:.*"
+ARG VGRID_CREATORS="distinguished_name:.*"
+ARG VGRID_MANAGERS="distinguished_name:.*"
+ARG DEFAULT_VGRID_LINKS="files web"
+ARG ADVANCED_VGRID_LINKS="files web scm tracker workflows monitor"
+ARG HG_PATH=/usr/bin/hg
+ARG HGWEB_SCRIPTS=/usr/share/doc/mercurial
+ARG TRAC_ADMIN_PATH=""
+ARG TRAC_INI_PATH=""
+ARG EMULATE_FLAVOR=migrid
+ARG EMULATE_FQDN=migrid.org
+ARG SKIN_SUFFIX=basic
+ARG ENABLE_OPENID=True
+ARG ENABLE_SFTP=True
+ARG ENABLE_SFTP_SUBSYS=True
+ARG ENABLE_DAVS=True
+ARG ENABLE_FTPS=True
+ARG ENABLE_SHARELINKS=True
+ARG ENABLE_TRANSFERS=True
+ARG ENABLE_DUPLICATI=True
+ARG ENABLE_SEAFILE=False
+ARG SEAFILE_FQDN=
+ARG SEAFILE_RO_ACCESS=False
+ARG ENABLE_SANDBOXES=False
+ARG ENABLE_VMACHINES=False
+ARG ENABLE_CRONTAB=True
+ARG ENABLE_JOBS=True
+ARG ENABLE_RESOURCES=True
+ARG ENABLE_EVENTS=True
+ARG ENABLE_GRAVATARS=True
+ARG ENABLE_SITESTATUS=True
+ARG STATUS_SYSTEM_MATCH="ANY"
+ARG ENABLE_FREEZE=False
+ARG PERMANENT_FREEZE=""
+ARG FREEZE_TO_TAPE=""
+ARG ENABLE_CRACKLIB=True
+ARG ENABLE_IMNOTIFY=False
+ARG ENABLE_NOTIFY=True
+ARG ENABLE_WORKFLOWS=False
+ARG ENABLE_VERIFY_CERTS=True
+ARG ENABLE_JUPYTER=True
+ARG ENABLE_CLOUD=False
+ARG CLOUD_ACCESS=cloud-access.yaml
+ARG CLOUD_JUMPHOST_KEY=cloud-jumphost-key
+ARG OPENSTACKSDK_VERSION_OVERRIDE=
+ARG ENABLE_MIGADMIN=False
+# We leave janitor disabled by default for now to allow more testing
+ARG ENABLE_JANITOR=False
+ARG ENABLE_GDP=False
+ARG ENABLE_TWOFACTOR=True
+ARG ENABLE_TWOFACTOR_STRICT_ADDRESS=False
+ARG TWOFACTOR_AUTH_APPS=""
+ARG ENABLE_PEERS=True
+ARG ENABLE_QUOTA=False
+ARG PEERS_MANDATORY=False
+ARG PEERS_EXPLICIT_FIELDS=""
+ARG PEERS_CONTACT_HINT="authorized to invite you as peer"
+ARG ENABLE_SELF_SIGNED_CERTS=False
+ARG MIG_PASSWORD_POLICY="MEDIUM"
+ARG ENABLE_LOGROTATE="False"
+# TODO: logrotate conf needs to be adjusted to the manual docker service launch 
+#ARG LOGROTATE_MIGRID="True"
+ARG LOGROTATE_MIGRID="False"
+# NOTE: mod auth openidc may be outdated in OS repo - allow optional upgrade
+ARG UPGRADE_MOD_AUTH_OPENIDC=False
+# NOTE: source for optional mod auth openidc upgrade
+#       Defaults to a relatively recent upstream release if left unset.
+#       Alternatives are available at
+#       https://github.com/OpenIDC/cjose/releases
+#       https://github.com/OpenIDC/mod_auth_openidc/releases
+ARG UPGRADE_OIDC_CJOSE_SRC=""
+ARG UPGRADE_OIDC_AUTH_MOD_SRC=""
+# NOTE: paramiko is a bit dated in OS repo - allow optional upgrade
+ARG UPGRADE_PARAMIKO=False
+ARG PUBKEY_FROM_DNS=False
+# NOTE: python2 support is gone on rocky9+
+ARG WITH_PY3=True
+ARG PREFER_PYTHON3=True
+ARG SIGNUP_METHODS=migoid
+ARG LOGIN_METHODS=migoid
+ARG USER_INTERFACES=V3
+# TODO: expose and enable new user default UI
+#ARG NEW_USER_DEFAULT_UI=V3
+ARG AUTO_ADD_CERT_USER=False
+ARG AUTO_ADD_OID_USER=False
+ARG AUTO_ADD_OIDC_USER=False
+ARG AUTO_ADD_FILTER_FIELDS=
+ARG AUTO_ADD_FILTER_METHOD=
+ARG AUTO_ADD_USER_PERMIT="distinguished_name:.*"
+ARG CERT_VALID_DAYS=365
+ARG OID_VALID_DAYS=365
+ARG GENERIC_VALID_DAYS=365
+ARG EXT_OIDC_PKCE_METHOD=""
+ARG EXT_OIDC_PROVIDER_ISSUER=""
+ARG EXT_OIDC_PROVIDER_AUTHORIZATION_ENDPOINT=""
+ARG EXT_OIDC_PROVIDER_TOKEN_ENDPOINT=""
+ARG EXT_OIDC_PROVIDER_USER_INFO_ENDPOINT=""
+ARG EXT_OIDC_PROVIDER_TOKEN_ENDPOINT_AUTH=""
+ARG EXT_OIDC_USER_INFO_TOKEN_METHOD=""
+ARG EXT_OIDC_USER_INFO_SIGNED_RESPONSE_ALG=""
+ARG EXT_OIDC_COOKIE_SAME_SITE=""
+ARG EXT_OIDC_PASS_COOKIES=""
+ARG EXT_OIDC_RESPONSE_MODE=""
+ARG EXT_OIDC_PROVIDER_VERIFY_CERT_FILES=""
+ARG EXT_OIDC_PRIVATE_KEY_FILES=""
+ARG EXT_OIDC_PUBLIC_KEY_FILES=""
+ARG EXT_OIDC_ID_TOKEN_ENCRYPTED_RESPONSE_ALG=""
+ARG EXT_OIDC_ID_TOKEN_ENCRYPTED_RESPONSE_ENC=""
+ARG EXT_OIDC_REWRITE_COOKIE=""
+ARG EXT_OIDC_TITLE=""
+ARG DEFAULT_MENU=
+ARG USER_MENU=jupyter
+ARG CA_FQDN=""
+ARG CA_SMTP="localhost"
+ARG CA_USER="mig-ca"
+ARG FTPS_PASV_PORTS="8100:8400"
+ARG SECSCAN_ADDR=""
+# TODO: expose and enable notify protocols
+#ARG NOTIFY_PROTOCOLS="email"
+ARG IMNOTIFY_ADDRESS=""
+ARG IMNOTIFY_CHANNEL=""
+ARG IMNOTIFY_USERNAME=""
+ARG IMNOTIFY_PASSWD=""
+ARG EXTERNAL_DOC="https://sourceforge.net/p/migrid/wiki"
+ARG IO_ACCOUNT_EXPIRE="False"
+# TODO: expose and enable these UI vars
+#ARG PEERS_NOTICE=""
+#ARG LOGO_CENTER=""
+#ARG SUPPORT_TEXT=""
+#ARG PRIVACY_TEXT=""
+ARG DATASAFETY_LINK=""
+ARG DATASAFETY_TEXT=""
+# NOTE: no python2 here and we already get 4.3+ for python3
+ARG MODERN_WSGIDAV=False
+ARG WITH_GIT=False
+ARG OPENSSH_VERSION=7.4
+ARG VGRID_LABEL=VGrid
+ARG DIGEST_SALT="AUTO"
+ARG CRYPTO_SALT="AUTO"
+ARG EXTRA_USERPAGE_SCRIPTS=""
+ARG EXTRA_USERPAGE_STYLES=""
+ARG GDP_EMAIL_NOTIFY=True
+ARG GDP_ID_SCRAMBLE=safe_hash
+ARG GDP_PATH_SCRAMBLE=safe_encrypt
+ARG STORAGE_PROTOCOLS=AUTO
+ARG WWWSERVE_MAX_BYTES=-1
+ARG SFTP_MAX_SESSIONS=32
+ARG WSGI_PROCS=25
+ARG APACHE_WORKER_PROCS=256
+ARG QUOTA_BACKEND=""
+ARG QUOTA_USER_LIMIT=1099511627776
+ARG QUOTA_VGRID_LIMIT=1099511627776
+ARG QUOTA_LUSTRE_VERSION="2.15.4"
+ARG QUOTA_LUSTRE_BASE="/dev/null"
+ARG QUOTA_GOCRYPTFS_XRAY="/dev/null"
+ARG QUOTA_GOCRYPTFS_SOCK="/dev/null"
+
+# Jupyter Arguments
+ARG JUPYTER_SERVICES=""
+ARG JUPYTER_SERVICES_ENABLE_PROXY_HTTPS=True
+ARG JUPYTER_SERVICES_PROXY_CONFIG="{}"
+ARG JUPYTER_SERVICES_DESC="{}"
+# Cloud Arguments
+ARG CLOUD_SERVICES=""
+ARG CLOUD_SERVICES_DESC="{}"
+
+#------------------------- first stage -----------------------------#
+FROM --platform=linux/$ARCH rockylinux:10 AS init
+ARG UID
+ARG GID
+ARG DOMAIN
+ARG WILDCARD_DOMAIN
+ARG PUBLIC_DOMAIN
+ARG MIGCERT_DOMAIN
+ARG EXTCERT_DOMAIN
+ARG MIGOID_DOMAIN
+ARG EXTOID_DOMAIN
+ARG EXTOIDC_DOMAIN
+ARG SID_DOMAIN
+ARG IO_DOMAIN
+ARG OPENID_DOMAIN
+ARG FTPS_DOMAIN
+ARG SFTP_DOMAIN
+ARG WEBDAVS_DOMAIN
+ARG PUBLIC_HTTP_PORT
+ARG PUBLIC_HTTPS_PORT
+ARG MIGCERT_HTTPS_PORT
+ARG EXTCERT_HTTPS_PORT
+ARG MIGOID_HTTPS_PORT
+ARG EXTOID_HTTPS_PORT
+ARG EXTOIDC_HTTPS_PORT
+ARG SID_HTTPS_PORT
+ARG SFTP_PORT
+ARG SFTP_SUBSYS_PORT
+ARG DAVS_PORT
+ARG FTPS_CTRL_PORT
+ARG OPENID_PORT
+#ARG MIG_SVN_REPO
+#ARG MIG_SVN_REV
+#ARG MIG_GIT_REPO
+#ARG MIG_GIT_BRANCH
+#ARG MIG_GIT_REV
+#ARG EMULATE_FLAVOR
+#ARG EMULATE_FQDN
+ARG WITH_PY3
+ARG JUPYTER_SERVICES
+ARG CLOUD_SERVICES
+#ARG WITH_GIT
+
+RUN echo "*** BEGIN Build variables ***" && \
+    echo "UID and GID: $UID $GID" && \
+    echo "Domains: $DOMAIN" "${PUBLIC_DOMAIN}" "${MIGCERT_DOMAIN}" \
+           "${EXTCERT_DOMAIN}" "${MIGOID_DOMAIN}" "${EXTOID_DOMAIN}" \
+           "${EXTOIDC_DOMAIN}" "${SID_DOMAIN}" "${IO_DOMAIN}" \
+           "${OPENID_DOMAIN}" "${SFTP_DOMAIN}" "${FTPS_DOMAIN}" \
+           "${WEBDAVS_DOMAIN}" && \
+    echo "Ports: " "${PUBLIC_HTTP_PORT} ${PUBLIC_HTTPS_PORT}" \
+    "${MIGOID_HTTPS_PORT} ${EXTOID_HTTPS_PORT} ${EXTOIDC_HTTPS_PORT}" \
+    "${MIGCERT_HTTPS_PORT} ${EXTCERT_HTTPS_PORT}" \
+    "${SID_HTTPS_PORT} ${SFTP_PORT} ${SFTP_SUBSYS_PORT}" \
+    "${FTPS_CTRL_PORT} ${DAVS_PORT} ${OPENID_PORT}" && \
+    #echo "MiG svn repo and revision: $MIG_SVN_REPO $MIG_SVN_REV" && \
+    echo "Enable git checkout & repo : $WITH_GIT $MIG_GIT_REPO" && \
+    echo "MiG git branch & revision:  $MIG_GIT_BRANCH $MIG_GIT_REV" && \
+    echo "Emulate flavor & fqdn: $EMULATE_FLAVOR $EMULATE_FQDN" && \
+    echo "Enable python3 support: $WITH_PY3" && \
+    #echo "Designated jupyter services: $JUPYTER_SERVICES" && \
+    #echo "Designated cloud services: $CLOUD_SERVICES" && \
+    echo "*** END Build variables ***"
+
+#------------------------- next stage -----------------------------#
+FROM --platform=linux/$ARCH init AS base
+ARG DOMAIN
+ARG WILDCARD_DOMAIN
+ARG ENABLE_GDP
+ARG ENABLE_SELF_SIGNED_CERTS
+ARG UPGRADE_MOD_AUTH_OPENIDC
+ARG UPGRADE_OIDC_CJOSE_SRC
+ARG UPGRADE_OIDC_AUTH_MOD_SRC
+ARG UPGRADE_PARAMIKO
+ARG ENABLE_CLOUD
+ARG WITH_PY3
+ARG PREFER_PYTHON3
+ARG UID
+ARG GID
+ARG SMTP_SERVER
+ARG SMTP_PORT
+ARG ADMIN_EMAIL
+ARG ENABLE_OPENID
+
+WORKDIR /tmp
+
+# Add common shell aliases
+COPY shell-aliases.sh /etc/profile.d/
+
+# Rocky image default dnf configs prevent doc installation like CentOS yum used to do
+# https://superuser.com/questions/784451/centos-on-docker-how-to-install-doc-files
+RUN sed -i '/nodocs/d' /etc/dnf/dnf.conf
+
+# NOTE: Enable crb repo by default on rocky9 for cracklib-devel, sshfs, ...
+RUN dnf update -y \
+    && dnf install -y epel-release dnf-plugins-core \
+    && dnf config-manager --enable crb \
+    && dnf clean all \
+    && rm -fr /var/cache/dnf
+
+RUN dnf update -y \
+    # NOTE: mod_auth_openidc is available by default on rocky9+
+    && dnf install -y \
+    gcc \
+    make \
+    glibc-langpack-en \
+    pam-devel \
+    nss-devel \
+    openssl-devel \
+    httpd \
+    htop \
+    openssh \
+    cronie \
+    crontabs \
+    nano \
+    mod_ssl \
+    # NOTE: mod_proxy is included in base httpd now
+    #mod_proxy \
+    # NOTE: OpenID 2.0 needs special care here
+    #mod_auth_openid \
+    mod_auth_openidc \
+    tzdata \
+    initscripts \
+    svn \
+    git \
+    vim \
+    net-tools \
+    telnet \
+    ca-certificates \
+    mercurial \
+    openssh-server \
+    openssh-clients \
+    rsyslog \
+    rsyslog-gnutls \
+    lsof \
+    # NOTE: python2 support is gone on rocky9+
+    # NOTE: generally install cracklib from pip as yum/dnf doesn't have it
+    #cracklib-python \
+    cracklib-devel \
+    # NOTE: extra dependencies required for paramiko pip install
+    redhat-rpm-config pkg-config rust cargo libffi-devel \
+    lftp \
+    rsync \
+    fail2ban \
+    ipset \
+    wget \
+    patch \
+    esmtp \
+    && dnf clean all \
+    && rm -fr /var/cache/dnf
+
+RUN if [ "${WITH_PY3}" = "True" ]; then \
+      echo "install py3 deps" \
+      && dnf update -y \
+      && dnf install -y \
+      python3-pip \
+      python3-devel \
+      python3-mod_wsgi \
+      python3-enchant \
+      #python3-jsonrpclib \
+      python3-requests \
+      python3-psutil \
+      python3-email-validator \
+      python3-future \
+      python3-cffi \
+      python3-openid \
+      python3-pyOpenSSL \
+      # NOTE: lxml and libxslt-devel required to build python-openid2
+      python3-lxml \
+      python3-pycurl \
+      python3-PyYAML \
+      # NOTE: we can just use native Cryptography and typing-extensions here
+      python3-cryptography \
+      python3-typing-extensions \
+      # Patch python3-openid until our pull request makes it to the Rocky repo
+      && echo "Pull python3 openid patch from own repo" \
+      && wget -q -O /tmp/python3-openid-assoc_handle.patch.diff https://raw.githubusercontent.com/ucphhpc/docker-migrid/master/patches/python3-openid-assoc_handle.patch.diff \
+      && patch -p 0 /usr/lib/python3.9/site-packages/openid/server/server.py < /tmp/python3-openid-assoc_handle.patch.diff \
+      && rm -f /tmp/python3-openid-assoc_handle.patch.diff \
+      # NOTE: only install default paramiko if upgrade not requested
+      && [ "${UPGRADE_PARAMIKO}" = "True" ] || dnf install -y python3-paramiko \
+      # NOTE: only install default openstack client if upgrade not requested
+      && [ "${ENABLE_CLOUD}" != "True" ] || dnf install -y python3-openstackclient \
+      && dnf clean all \
+      && rm -fr /var/cache/dnf; \
+    else \
+      echo "no py3 deps"; \
+    fi;
+
+# Containers have esmtp installed by default but we explicitly include it above
+# and configure it for host SMTP delivery for cronjobs etc to be able to route
+# mail outside containers.
+RUN if [ -n "${SMTP_SERVER}" ]; then \
+      [ -z "${SMTP_PORT}" ] && SMTP_PORT=25; \
+      echo "# Simple SMTP setup to route all local mail to host SMTP" > /etc/esmtprc \
+      && echo "hostname ${SMTP_SERVER}:${SMTP_PORT}" >> /etc/esmtprc \
+      && echo "qualifydomain ${DOMAIN}" >> /etc/esmtprc \
+      && echo "force reverse_path %u@${DOMAIN}" >> /etc/esmtprc ; \
+    fi
+
+# NOTE: python extensions libpam and libnss need matching python-config
+RUN if [ "${PREFER_PYTHON3}" = "True" ]; then \
+      echo "set up py3 as default python and python-config" && \
+      update-alternatives --install /usr/bin/python python /usr/bin/python3 10; \
+      update-alternatives --install /usr/bin/python-config python-config /usr/bin/python3-config 10; \
+    else \
+      echo "*** No python2 support here ***" ; exit 1; \
+    fi;
+
+
+# Install GDP dependencies
+RUN if [ "${ENABLE_GDP}" = "True" ]; then \
+      echo "install GDP deps" \
+      && dnf update -y \
+      && dnf install -y \
+      # NOTE: python2 support is gone on rocky9+
+      xorg-x11-server-Xvfb \
+      # NOTE: wkhtmltopdf not yet build for Rocky9 
+      https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox-0.12.6-1.centos8.x86_64.rpm \
+      # NOTE: compat-openssl11.x86_64 is needed by Rocky8 version of wkhtmltopdf 
+      compat-openssl11.x86_64 \
+      && dnf clean all \
+      && rm -fr /var/cache/dnf; \
+      if [ "${WITH_PY3}" = "True" ]; then \
+         echo "install py3 deps" && \
+         pip3 install --no-cache-dir xvfbwrapper && \
+	     pip3 install --no-cache-dir pdfkit; \
+      fi; \
+    else \
+      echo "no GDP deps"; \
+    fi;
+
+
+# Build Apache OpenID (provided by epel for centos7) 
+RUN if [ "$ENABLE_OPENID" = "True" ]; then \
+        echo "building mod_auth_openid from centos7 source rpm" \
+        && dnf update -y \
+        && dnf install -y gcc-c++ \
+            rpm-build \
+            mock \
+            make \
+            autoconf \
+            automake \
+            httpd-devel \
+            libcurl-devel \
+            libtidy-devel \
+            pcre-devel \
+            openssl-devel \
+            libtool \
+            sqlite-devel \
+            boost-devel \
+            libxslt \
+            expat-devel \
+            tidy-devel \
+            libuuid-devel \
+        && dnf clean all \
+        && rm -fr /var/cache/dnf \
+        # NOTE: add EPEL CentOS 7 repos here but completely disabled
+        # NOTE: rocky9 switched from explicit version to variable expansion
+        #      as in 9 - > $releasever
+        && cat /etc/yum.repos.d/epel.repo | \
+                sed 's/\[epel/\[epel7/g;s/\(epel[a-z-]*\)-9/\1-7/g;s/\$releasever/7/g;s/enabled=1/enabled=0/g' \
+                > /etc/yum.repos.d/epel7.repo \
+        && echo "build libopkele from centos7 source rpm" \
+        # NOTE: avoid hard-coded version using yumdownloader from yum-utils
+        && yumdownloader -y --enablerepo=epel7-source --source --resolve --destdir /root/rpmbuild/SRPMS libopkele \
+        && rpm -ivh /root/rpmbuild/SRPMS/libopkele-*.src.rpm \
+        # Optionally pull more recent gcc4.9 patch from Debian on rocky8+ (local copy in patches)
+        && wget -q -O /root/rpmbuild/SOURCES/fix-ftbfs-gcc4.9.diff https://sources.debian.org/data/main/libo/libopkele/2.0.4%2Bgit20140305.9651b55-4/debian/patches/fix-ftbfs-gcc4.9.diff \
+        # Pull the more recent required OpenSSL-1.1 patch from Debian on rocky8+ (local copy in patches)
+        && wget -q -O /root/rpmbuild/SOURCES/fix-openssl-1.1.0.diff https://sources.debian.org/data/main/libo/libopkele/2.0.4%2Bgit20140305.9651b55-4/debian/patches/fix-openssl-1.1.0.diff \
+        # Pull patch from own repo to rpmbuild with Debian patches on rocky8+ (local copy in patches)
+        && wget -q -O /tmp/rpmbuild-opkele-with-gcc4.9-openssl-1.1.0-patches.diff https://github.com/ucphhpc/docker-migrid/raw/master/patches/rpmbuild-opkele-with-gcc4.9-openssl-1.1.0-patches.diff \
+        && cd /root && patch -p 0 < /tmp/rpmbuild-opkele-with-gcc4.9-openssl-1.1.0-patches.diff && cd - \
+        && rpmbuild -v -ba /root/rpmbuild/SPECS/libopkele.spec \
+        && rm -f /root/rpmbuild/RPMS/*/libopkele-*debug*.rpm \
+        #&& dnf erase -y 'libopkele-*' \
+        && dnf install -y /root/rpmbuild/RPMS/*/libopkele-*.rpm \
+        && echo "install mod_auth_openid centos7 source rpm" \
+        #&& rpm -e --nodeps mod_auth_openid \
+        # NOTE: avoid hard-coded version using yumdownloader from yum-utils
+        && yumdownloader -y --enablerepo=epel7-source --source --resolve --destdir /root/rpmbuild/SRPMS mod_auth_openid \
+        && rpm -ivh /root/rpmbuild/SRPMS/mod_auth_openid-*.src.rpm \
+        && echo "build mod_auth_openid centos7 source rpm" \
+        && rpmbuild -v -ba /root/rpmbuild/SPECS/mod_auth_openid.spec \
+        && rm -f /root/rpmbuild/RPMS/*/mod_auth_openid-*debug*.rpm \
+        && echo "install the rebuilt mod_auth_openid rpm" \
+        #&& dnf erase -y 'mod_auth_openid-*' \
+        && dnf install -y /root/rpmbuild/RPMS/*/mod_auth_openid-*.rpm \
+        && echo "cleaning up after rebuilding and installing mod_auth_openid rpm" \
+        && rm -rf /root/rpmbuild \
+        && dnf clean all \
+        && rm -fr /var/cache/dnf; \
+    fi;
+
+
+# Upgrade mod_auth_openidc from upstream github packages if requested - mainly needed for rhel/centos7
+# https://stackoverflow.com/questions/68742362/how-to-install-mod-auth-openidc-on-rhel-7
+# The module requires a recent cjose library version. Packaged versions are
+# also available on the upstream releases page under the 2.4.0 release Assets.
+# Version 2.4.12.1+ is needed to support the OIDCPassClaimsAs encoding setting in apache conf
+RUN echo "UPGRADE_MOD_AUTH_OPENIDC: $UPGRADE_MOD_AUTH_OPENIDC"
+RUN if [ "$UPGRADE_MOD_AUTH_OPENIDC" = "True" ]; then \
+        if [ -z "${UPGRADE_OIDC_AUTH_MOD_SRC}" ]; then \
+		echo "upgrading mod_auth_openidc from upstream release package"; \
+		UPGRADE_OIDC_AUTH_MOD_SRC="https://github.com/OpenIDC/mod_auth_openidc/releases/download/v2.4.16.11/mod_auth_openidc-2.4.16.11-1.el9.x86_64.rpm"; \
+	else \
+		echo "upgrading mod_auth_openidc from ${UPGRADE_OIDC_AUTH_MOD_SRC}"; \
+	fi; \ 
+        if [ -z "${UPGRADE_OIDC_CJOSE_SRC}" ]; then \
+		# NOTE: recent cjose is already included in rocky8+ but lacks security fix
+		#echo "installing cjose dependency from OS package"; \
+		#UPGRADE_OIDC_CJOSE_SRC="cjose"; \
+		echo "upgrading cjose from upstream release package"; \
+		UPGRADE_OIDC_CJOSE_SRC="https://github.com/OpenIDC/cjose/releases/download/v0.6.2.3/cjose-0.6.2.3-1.el9.x86_64.rpm"; \
+	else \
+		echo "upgrading cjose from ${UPGRADE_OIDC_CJOSE_SRC}"; \
+	fi; \
+	dnf update -y \
+	# IMPORTANT: fail hard if any of these installs don't succeed e.g. due
+	#            to missing upstream packages to avoid silent errors later.
+	&& dnf install -y jansson-devel \
+	&& dnf install -y \
+		"${UPGRADE_OIDC_CJOSE_SRC}" \
+	&& dnf install -y \
+		"${UPGRADE_OIDC_AUTH_MOD_SRC}" \
+	&& dnf clean all \
+	&& rm -fr /var/cache/dnf; \
+	if [ $? -ne 0 ]; then \
+		echo "Upgrade Apache OpenID Connect module failed!"; exit 1; \
+	fi; \
+    fi;
+
+
+# Setup container default language to make sure UTF8 is available in wsgi app.
+# Otherwise sys.getfilesystemencoding will return ascii despite utf8 FS, and
+# thus result e.g. in broken user path and client_id for users with accented
+# chars e.g. in their name.
+# https://stackoverflow.com/a/28212946
+# NOTE: it looks like we don't need to generate this rather common locale here
+#       but on some platforms it's needed to install an English language pack
+#       to avoid various LC_X locale warnings and errors.
+#RUN localedef -c -i en_US -f UTF-8 en_US.UTF-8
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
+# Setup user
+ENV USER=mig
+ENV GROUP=mig
+
+RUN groupadd -g $GID $USER
+# NOTE: use -l to avoid excessively large image (hadolint hint)
+RUN useradd -l -u $UID -g $GID -ms /bin/bash $USER
+
+# MiG environment
+ENV MIG_ROOT=/home/$USER
+ENV WEB_DIR=/etc/httpd
+ENV CERT_DIR=$WEB_DIR/MiG-certificates
+ENV HOTFIXES_DIR=/hotfixes
+
+USER root
+
+RUN mkdir -p ${CERT_DIR}/MiG/${WILDCARD_DOMAIN} ${HOTFIXES_DIR} \
+    && chown $USER:$GROUP ${CERT_DIR} \
+    && chmod 775 ${CERT_DIR} \
+    && chmod 700 ${HOTFIXES_DIR}
+
+#------------------------- next stage -----------------------------#
+# Certs and keys
+FROM --platform=linux/$ARCH base AS setup_security
+ARG DOMAIN
+ARG WILDCARD_DOMAIN
+ARG PUBLIC_DOMAIN
+ARG PUBLIC_SEC_DOMAIN
+ARG PUBLIC_ALIAS_DOMAIN
+ARG STATUS_ALIAS_DOMAIN
+ARG MIGCERT_DOMAIN
+ARG EXTCERT_DOMAIN
+ARG MIGOID_DOMAIN
+ARG EXTOID_DOMAIN
+ARG EXTOIDC_DOMAIN
+ARG SID_DOMAIN
+ARG IO_DOMAIN
+ARG OPENID_DOMAIN
+ARG FTPS_DOMAIN
+ARG SFTP_DOMAIN
+ARG WEBDAVS_DOMAIN
+ARG OS_CA_CERT_SOURCE_PATH=/etc/pki/ca-trust/source/anchors
+
+# Copy in any existing keys+certificates that should be used in containers
+COPY certs/ ${CERT_DIR}/
+
+# Dhparam - https://wiki.mozilla.org/Security/Archive/Server_Side_TLS_4.0
+RUN if [ ! -e "${CERT_DIR}/.persistent" ]; then \
+    curl https://ssl-config.mozilla.org/ffdhe4096.txt -o ${CERT_DIR}/dhparams.pem ; fi
+
+# CA
+# https://gist.github.com/Soarez/9688998
+RUN if [ ! -e "${CERT_DIR}/.persistent" ]; then \
+    openssl genrsa -des3 -passout pass:qwerty -out ca.key 2048 \
+    && openssl rsa -passin pass:qwerty -in ca.key -out ca.key \
+    && openssl req -x509 -new -key ca.key \
+    -subj "/C=DK/ST=NA/L=NA/O=MiGrid-Test/OU=NA/CN=${WILDCARD_DOMAIN}" -out ca.crt \
+    && openssl req -x509 -new -nodes -key ca.key -sha256 -days 1024 \
+    -subj "/C=DK/ST=NA/L=NA/O=MiGrid-Test/OU=NA/CN=${WILDCARD_DOMAIN}" -out ca.pem ; fi
+
+# Server key/ca
+# https://gist.github.com/Soarez/9688998
+RUN if [ ! -e "${CERT_DIR}/.persistent" ]; then \
+    openssl genrsa -out server.key 2048 \
+    && openssl req -new -key server.key -out server.csr \
+    -subj "/C=DK/ST=NA/L=NA/O=MiGrid-Test/OU=NA/CN=${WILDCARD_DOMAIN}" \
+    && openssl x509 -req -days 365 -in server.csr -signkey server.key -out server.crt ; fi
+
+# Certificate Revocation List (CRL)
+RUN if [ ! -e "${CERT_DIR}/.persistent" ]; then \
+    mkdir -p /etc/pki/CA \
+    && touch /etc/pki/CA/index.txt \
+    && echo '00' > /etc/pki/CA/crlnumber \
+    && openssl ca -gencrl -keyfile ca.key -cert ca.pem -out crl.pem ; fi
+
+# Daemon keys
+RUN if [ ! -e "${CERT_DIR}/.persistent" ]; then \
+    cat server.{key,crt} > combined.pem \
+    && cat server.crt > server.ca.pem \
+    && cat ca.pem >> server.ca.pem \
+    && chown $USER:$GROUP combined.pem \
+    && chown $USER:$GROUP server.ca.pem \
+    && ssh-keygen -y -f combined.pem > combined.pub \
+    && chown 0:0 ./*.key server.crt ca.pem \
+    && chmod 400 ./*.key server.crt ca.pem combined.pem server.ca.pem \
+    && openssl x509 -noout -fingerprint -sha256 -in combined.pem | \
+       sed 's/.* Fingerprint=//g' > combined.pem.sha256 \
+    && ssh-keygen -l -E md5 -f combined.pub | \
+       sed 's/.* MD5://g;s/ .*//g' > combined.pub.md5 \
+    && ssh-keygen -l -f combined.pub | \
+       sed 's/.* SHA256://g;s/ .*//g' > combined.pub.sha256; fi
+
+# Prepare keys for mig
+RUN if [ ! -e "${CERT_DIR}/.persistent" ]; then \
+    mv server.crt ${CERT_DIR}/MiG/${WILDCARD_DOMAIN}/ \
+    && mv server.key ${CERT_DIR}/MiG/${WILDCARD_DOMAIN}/ \
+    && mv crl.pem ${CERT_DIR}/MiG/${WILDCARD_DOMAIN}/ \
+    && mv ca.pem ${CERT_DIR}/MiG/${WILDCARD_DOMAIN}/cacert.pem \
+    && mv combined.pem ${CERT_DIR}/MiG/${WILDCARD_DOMAIN}/ \
+    && mv combined.pem.sha256 ${CERT_DIR}/MiG/${WILDCARD_DOMAIN}/ \
+    && mv combined.pub ${CERT_DIR}/MiG/${WILDCARD_DOMAIN}/ \
+    && mv combined.pub.md5 ${CERT_DIR}/MiG/${WILDCARD_DOMAIN}/ \
+    && mv combined.pub.sha256 ${CERT_DIR}/MiG/${WILDCARD_DOMAIN}/ \
+    && mv server.ca.pem ${CERT_DIR}/MiG/${WILDCARD_DOMAIN}/ ; fi
+
+WORKDIR ${CERT_DIR}
+
+RUN if [ ! -e "${CERT_DIR}/.persistent" ]; then \
+    ln -s MiG/${WILDCARD_DOMAIN}/server.crt server.crt \
+    && ln -s MiG/${WILDCARD_DOMAIN}/server.key server.key \
+    && ln -s MiG/${WILDCARD_DOMAIN}/crl.pem crl.pem \
+    && ln -s MiG/${WILDCARD_DOMAIN}/cacert.pem cacert.pem \
+    && ln -s MiG/${WILDCARD_DOMAIN}/combined.pem combined.pem \
+    && ln -s MiG/${WILDCARD_DOMAIN}/combined.pem.sha256 combined.pem.sha256 \
+    && ln -s MiG/${WILDCARD_DOMAIN}/server.ca.pem server.ca.pem \
+    && ln -s MiG/${WILDCARD_DOMAIN}/combined.pub combined.pub \
+    && ln -s MiG/${WILDCARD_DOMAIN}/combined.pub.md5 combined.pub.md5 \
+    && ln -s MiG/${WILDCARD_DOMAIN}/combined.pub.sha256 combined.pub.sha256 \
+    && for domain in "${PUBLIC_DOMAIN}" "${PUBLIC_SEC_DOMAIN}" \
+           "${PUBLIC_ALIAS_DOMAIN}" "${STATUS_ALIAS_DOMAIN}" \
+           "${MIGCERT_DOMAIN}" "${EXTCERT_DOMAIN}" \
+           "${MIGOID_DOMAIN}" "${EXTOID_DOMAIN}" "${EXTOIDC_DOMAIN}" \
+           "${SID_DOMAIN}" "${IO_DOMAIN}" "${OPENID_DOMAIN}" "${SFTP_DOMAIN}" \
+           "${FTPS_DOMAIN}" "${WEBDAVS_DOMAIN}"; do \
+               [ -L "$domain" ] || ln -s MiG/${WILDCARD_DOMAIN} $domain; \
+       done ; fi
+
+# Upgrade pip3 is only required for cryptography from pip - irrelevant here
+#RUN if [ "${WITH_PY3}" = "True" ]; then \
+#      python3 -m pip install --no-cache-dir -U 'pip'; \
+#    fi;
+
+# NOTE: make certs as mig user
+WORKDIR $MIG_ROOT
+USER $USER
+
+RUN mkdir -p MiG-certificates \
+    && cd MiG-certificates \
+    && ln -s ${CERT_DIR}/MiG/${WILDCARD_DOMAIN}/cacert.pem cacert.pem \
+    && ln -s ${CERT_DIR}/MiG MiG \
+    && ln -s ${CERT_DIR}/combined.pem combined.pem \
+    && ln -s ${CERT_DIR}/combined.pem.sha256 combined.pem.sha256 \
+    && ln -s ${CERT_DIR}/combined.pub combined.pub \
+    && ln -s ${CERT_DIR}/combined.pub.md5 combined.pub.md5 \
+    && ln -s ${CERT_DIR}/combined.pub.sha256 combined.pub.sha256 \
+    && ln -s ${CERT_DIR}/dhparams.pem dhparams.pem
+
+USER root
+WORKDIR /tmp
+# Copy in any external certificates that should be part of the OS trusted ca bundle
+RUN update-ca-trust force-enable
+COPY external-certificates/ ${OS_CA_CERT_SOURCE_PATH}/
+RUN update-ca-trust extract
+
+WORKDIR $MIG_ROOT
+USER $USER
+
+#------------------------- next stage -----------------------------#
+FROM --platform=linux/$ARCH setup_security AS mig_dependencies
+ARG DOMAIN
+ARG WITH_PY3
+ARG MODERN_WSGIDAV
+ARG UPGRADE_PARAMIKO
+ARG ENABLE_CLOUD
+ARG OPENSTACKSDK_VERSION_OVERRIDE
+ARG TRAC_ADMIN_PATH
+
+# NOTE: Switch back to root for system-wide pip install here
+USER root
+
+# Prepare py dependencies not in dnf or just outdated there
+
+# NOTE: use jsonrpclib and pysendfile from pip for py3 here
+RUN if [ "${WITH_PY3}" = "True" ]; then \
+      pip3 install --no-cache-dir 'jsonrpclib<0.2' pysendfile; \
+    fi;
+
+# NOTE: recent paramiko is required for modern host key algo
+RUN if [ "${UPGRADE_PARAMIKO}" = "True" ]; then \
+      if [ "${WITH_PY3}" = "True" ]; then \
+        # NOTE: a newer setuptools MAY be needed and setuptools_rust MUST be 
+        #       installed separately here for whatever reason.
+        # IMPORTANT: sftp_subsys.py is explicitly called with 'python -s' to
+        #            prevent loading arbitrary code libs from user home, but
+        #            with python3 that also excludes packages installed in
+        #            /usr/local, which is now the default install location for
+        #            pip3. Thus, we force pip3 to install the paramiko plus
+        #            dependencies specifically into /usr instead.
+        #pip3 install --no-cache-dir -U setuptools; \
+        #pip3 install --no-cache-dir setuptools_rust; \
+        # Additional NOTE: paramiko version 3.x introduces several changes
+        # that in particular improve the SFTP download performance.
+        # At the time of writing, the RHEL/Rocky 10 EPEL repo provides 3.5,
+        # which we use as a version baseline to mimic.
+        # However, combining that with recent bcrypt versions in the 4.x
+        # series leads to import errors in mod_wsgi caused by the usage of
+        # sub-interpreters as highlighted at
+        # https://github.com/PyO3/pyo3/blob/main/guide/src/migration.md#each-pymodule-can-now-only-be-initialized-once-per-process
+        # with further explanation at
+        # https://bugzilla.redhat.com/show_bug.cgi?id=2255688 and
+        # https://github.com/PyO3/pyo3/issues/3451
+        # So we explicitly cap the bcrypt version to the latest 3.2 one,
+        # which coincides with the default Rocky version, btw.
+        pip3 install --no-cache-dir --prefix=$(python3-config --prefix) 'paramiko>=3.5' 'bcrypt<4'; \
+      fi; \
+    fi;
+
+# NOTE: openstackclient is available in dnf here, but sdk may be requested
+#       e.g. to work around version 1.0.0 breaking floating IP assignment
+RUN if [ "${ENABLE_CLOUD}" = "True" ]; then \
+      #if [ "${WITH_PY3}" = "True" ]; then \
+      #  pip3 install --no-cache-dir python-openstackclient; \
+      #fi; \
+      if [ -n "${OPENSTACKSDK_VERSION_OVERRIDE}" ]; then \
+        pip3 install --no-cache-dir "openstacksdk==${OPENSTACKSDK_VERSION_OVERRIDE}" ; \
+      fi; \
+    fi;
+
+# OpenID support in python (python-openid2 for py3) - use alternative from dnf 
+#RUN pip3 install --no-cache-dir python-openid2;
+
+# Modules required by grid_events.py
+RUN if [ "${WITH_PY3}" = "True" ]; then \
+      pip3 install --no-cache-dir watchdog scandir; \
+    fi;
+
+# Modules required by grid_webdavs
+RUN if [ "${WITH_PY3}" = "True" ]; then \
+      # IMPORTANT: use at least 4.1 here to avoid a potential security issue 
+      # https://github.com/mar10/wsgidav/security/advisories/GHSA-xx6g-jj35-pxjv
+      # IMPORTANT: use cheroot before 10.0.1 as it currently crashes webdavs
+      #            One can trigger the crash with a simple testssl.sh run
+      # TODO: investigate if the problem is in cheroot, wsgidav or migrid.
+      pip3 install --no-cache-dir 'cheroot<10.0.1' 'wsgidav>=4.1.0'; \
+    fi;
+# Prefer sslkeylog as session tracking helper in webdavs daemon.
+RUN if [ "${WITH_PY3}" = "True" ]; then \
+      pip3 install --no-cache-dir sslkeylog ; \
+    fi;
+
+# Modules required by grid_ftps
+# NOTE: relies on pyOpenSSL and Cryptography from yum/dnf for now
+RUN if [ "${WITH_PY3}" = "True" ]; then \
+      pip3 install --no-cache-dir pyftpdlib; \
+    fi;
+
+# Modules required by grid_X IO daemons (not available in yum/dnf for python3)
+# IMPORTANT: install in main python site-packages to work with 'python -s'
+#            Otherwise sftpsubsys will fail to import it because the /usr/local
+#            dir used as prefix by default in pip is outside sys.path
+RUN if [ "${WITH_PY3}" = "True" ]; then \
+      pip3 install --no-cache-dir --prefix=$(python3-config --prefix) cracklib; \
+    fi;
+
+# Module required to run pytests
+RUN if [ "${WITH_PY3}" = "True" ]; then \
+      pip3 install --no-cache-dir pytest; \
+    fi;
+
+# Modules required by 2FA
+RUN if [ "${WITH_PY3}" = "True" ]; then \
+      pip3 install --no-cache-dir pyotp; \
+    fi;
+
+# Modules required for smart country selection
+RUN if [ "${WITH_PY3}" = "True" ]; then \
+      pip3 install --no-cache-dir iso3166; \
+    fi;
+
+# Modules required for email validation (already available in yum/dnf for python3)
+# IMPORTANT: install in main python site-packages to work with 'python -s'
+#            Otherwise sftpsubsys will fail to import it because the /usr/local
+#            dir used as prefix by default in pip is outside sys.path
+#RUN pip3 install --no-cache-dir --prefix=$(python3-config --prefix) email-validator;
+
+# Modules required for Trac integration 
+RUN if [ -n "${TRAC_ADMIN_PATH}" ]; then \
+      echo "install Trac and plugins" \
+      && pip3 install --no-cache-dir Trac TracWikiPrint TracGraphviz TracFullBlog TracWikiCssPlugin \
+      # IMPORTANT: Mercurial plugin is required for our repos and only recent
+      #            stable releases support current python and Trac versions.
+      #            We need 1.0.0.11+ for the default Python 3 and Trac-1.6.
+      && pip3 install --no-cache-dir 'TracMercurial>=1.0.0.11' \
+      # NOTE: these plugins would be nice but have gone stale and only support
+      #       older Trac versions.
+      #&& pip3 install --no-cache-dir TracStats TracMasterTickets TracDiscussion TracDownloads TracWysiwyg \
+      #&& pip3 install --no-cache-dir https://trac-hacks.org/svn/tracwysiwygplugin/0.12
+      # NOTE: install more recent dev versions of those with Trac-1.6+ support
+      # latest tag https://github.com/trac-hacks/tracstats/releases/tag/v0.6.1 is pre 1.6
+      && pip3 install --no-cache-dir https://github.com/trac-hacks/tracstats/archive/refs/heads/master.zip ; \
+    else \
+      echo "no Trac deps"; \
+    fi;
+
+# Modules required for workflows
+RUN if [ "${WITH_PY3}" = "True" ]; then \
+      pip3 install --no-cache-dir nbformat nbconvert papermill; \
+    fi;
+
+#------------------------- next stage -----------------------------#
+FROM --platform=linux/$ARCH mig_dependencies AS download_mig
+LABEL MIGRID=true
+ARG DOMAIN
+ARG MIG_SVN_REPO
+ARG MIG_SVN_REV
+ARG WITH_GIT
+ARG MIG_GIT_REPO
+ARG MIG_GIT_BRANCH
+ARG MIG_GIT_REV
+ARG PREFER_PYTHON3
+ARG MODERN_WSGIDAV
+
+WORKDIR $MIG_ROOT
+USER $USER
+
+# Install and configure MiG
+# NOTE: git refuses to clone into non-empty dir - use tmp
+
+RUN if [ "$WITH_GIT" = "True" ]; then \
+      git clone ${MIG_GIT_REPO} migrid.git && \
+        cd migrid.git && \
+        git checkout -B ${MIG_GIT_BRANCH} --track origin/${MIG_GIT_BRANCH} && \
+        git checkout ${MIG_GIT_REV} && cd .. && \
+        rsync -a migrid.git/ ./ && \
+        rm -rf migrid.git/ && \
+	echo "migrid version: ${MIG_GIT_REPO} ${MIG_GIT_BRANCH} ${MIG_GIT_REV}" > ./active-migrid-version.txt; \
+    else \
+      svn checkout -r ${MIG_SVN_REV} ${MIG_SVN_REPO} . && \
+	echo "migrid version: ${MIG_SVN_REPO} trunk ${MIG_SVN_REV}" > ./active-migrid-version.txt; \
+    fi;
+
+# NOTE: we manually need to enable modern grid_webdavs.py here for now.
+#       Replace any existing symlink with one to the 3.x script.
+RUN rm -f ${MIG_ROOT}/mig/server/grid_webdavs.py ; \
+    ln -s grid_webdavs-3.x.py ${MIG_ROOT}/mig/server/grid_webdavs.py;
+
+
+#------------------------- next stage -----------------------------#
+FROM --platform=linux/$ARCH download_mig AS install_mig
+ARG DOMAIN
+ARG PUBLIC_DOMAIN
+ARG PUBLIC_SEC_DOMAIN
+ARG PUBLIC_ALIAS_DOMAIN
+ARG STATUS_ALIAS_DOMAIN
+ARG MIGCERT_DOMAIN
+ARG EXTCERT_DOMAIN
+ARG MIGOID_DOMAIN
+ARG EXTOID_DOMAIN
+ARG EXTOIDC_DOMAIN
+ARG SID_DOMAIN
+ARG IO_DOMAIN
+ARG OPENID_DOMAIN
+ARG FTPS_DOMAIN
+ARG SFTP_DOMAIN
+ARG WEBDAVS_DOMAIN
+ARG PUBLIC_HTTP_PORT
+ARG PUBLIC_HTTPS_PORT
+ARG MIGCERT_HTTPS_PORT
+ARG EXTCERT_HTTPS_PORT
+ARG MIGOID_HTTPS_PORT
+ARG EXTOID_HTTPS_PORT
+ARG EXTOIDC_HTTPS_PORT
+ARG SID_HTTPS_PORT
+ARG SFTP_PORT
+ARG SFTP_SUBSYS_PORT
+ARG SFTP_SHOW_PORT
+ARG DAVS_PORT
+ARG DAVS_SHOW_PORT
+ARG FTPS_CTRL_PORT
+ARG FTPS_CTRL_SHOW_PORT
+ARG OPENID_PORT
+ARG OPENID_SHOW_PORT
+ARG ADMIN_EMAIL
+ARG ADMIN_LIST
+ARG SUPPORT_EMAIL
+ARG SMTP_SENDER
+ARG SMTP_SERVER
+ARG SMTP_PORT
+ARG LOG_LEVEL
+ARG TITLE
+ARG SHORT_TITLE
+ARG PEERS_PERMIT
+ARG VGRID_CREATORS
+ARG VGRID_MANAGERS
+ARG DEFAULT_VGRID_LINKS
+ARG ADVANCED_VGRID_LINKS
+ARG HG_PATH
+ARG HGWEB_SCRIPTS
+ARG TRAC_ADMIN_PATH
+ARG TRAC_INI_PATH
+ARG MIG_OID_TITLE
+ARG EXT_OID_TITLE
+ARG MIG_OID_PROVIDER
+ARG EXT_OID_PROVIDER
+ARG EXT_OIDC_PROVIDER_META_URL
+ARG EXT_OIDC_CLIENT_NAME
+ARG EXT_OIDC_CLIENT_ID
+ARG EXT_OIDC_SCOPE
+ARG EXT_OIDC_REMOTE_USER_CLAIM
+ARG EXT_OIDC_PASS_CLAIM_AS
+ARG EMULATE_FLAVOR
+ARG EMULATE_FQDN
+ARG SKIN_SUFFIX
+ARG ENABLE_OPENID
+ARG ENABLE_SFTP
+ARG ENABLE_SFTP_SUBSYS
+ARG ENABLE_DAVS
+ARG ENABLE_FTPS
+ARG ENABLE_SHARELINKS
+ARG ENABLE_TRANSFERS
+ARG ENABLE_DUPLICATI
+ARG ENABLE_SEAFILE
+ARG SEAFILE_FQDN
+ARG SEAFILE_RO_ACCESS
+ARG ENABLE_SANDBOXES
+ARG ENABLE_VMACHINES
+ARG ENABLE_CRONTAB
+ARG ENABLE_JOBS
+ARG ENABLE_RESOURCES
+ARG ENABLE_EVENTS
+ARG ENABLE_GRAVATARS
+ARG ENABLE_SITESTATUS
+ARG STATUS_SYSTEM_MATCH
+ARG ENABLE_FREEZE
+ARG PERMANENT_FREEZE
+ARG FREEZE_TO_TAPE
+ARG ENABLE_CRACKLIB
+ARG ENABLE_IMNOTIFY
+ARG ENABLE_NOTIFY
+ARG ENABLE_WORKFLOWS
+ARG ENABLE_VERIFY_CERTS
+ARG ENABLE_JUPYTER
+ARG ENABLE_CLOUD
+ARG CLOUD_ACCESS
+ARG CLOUD_JUMPHOST_KEY
+ARG ENABLE_MIGADMIN
+ARG ENABLE_JANITOR
+ARG ENABLE_GDP
+ARG ENABLE_TWOFACTOR
+ARG ENABLE_TWOFACTOR_STRICT_ADDRESS
+ARG TWOFACTOR_AUTH_APPS
+ARG ENABLE_PEERS
+ARG ENABLE_QUOTA
+ARG PEERS_MANDATORY
+ARG PEERS_EXPLICIT_FIELDS
+ARG PEERS_CONTACT_HINT
+ARG MIG_PASSWORD_POLICY
+ARG PUBKEY_FROM_DNS
+ARG PREFER_PYTHON3
+ARG SIGNUP_METHODS
+ARG LOGIN_METHODS
+ARG USER_INTERFACES
+ARG AUTO_ADD_CERT_USER
+ARG AUTO_ADD_OID_USER
+ARG AUTO_ADD_OIDC_USER
+ARG AUTO_ADD_FILTER_FIELDS
+ARG AUTO_ADD_FILTER_METHOD
+ARG AUTO_ADD_USER_PERMIT
+ARG CERT_VALID_DAYS
+ARG OID_VALID_DAYS
+ARG GENERIC_VALID_DAYS
+ARG EXT_OIDC_PKCE_METHOD
+ARG EXT_OIDC_PROVIDER_ISSUER
+ARG EXT_OIDC_PROVIDER_AUTHORIZATION_ENDPOINT
+ARG EXT_OIDC_PROVIDER_TOKEN_ENDPOINT
+ARG EXT_OIDC_PROVIDER_USER_INFO_ENDPOINT
+ARG EXT_OIDC_PROVIDER_TOKEN_ENDPOINT_AUTH
+ARG EXT_OIDC_USER_INFO_TOKEN_METHOD
+ARG EXT_OIDC_USER_INFO_SIGNED_RESPONSE_ALG
+ARG EXT_OIDC_COOKIE_SAME_SITE
+ARG EXT_OIDC_PASS_COOKIES
+ARG EXT_OIDC_RESPONSE_MODE
+ARG EXT_OIDC_PROVIDER_VERIFY_CERT_FILES
+ARG EXT_OIDC_PRIVATE_KEY_FILES
+ARG EXT_OIDC_PUBLIC_KEY_FILES
+ARG EXT_OIDC_ID_TOKEN_ENCRYPTED_RESPONSE_ALG
+ARG EXT_OIDC_ID_TOKEN_ENCRYPTED_RESPONSE_ENC
+ARG EXT_OIDC_REWRITE_COOKIE
+ARG EXT_OIDC_TITLE
+ARG DEFAULT_MENU
+ARG USER_MENU
+ARG CA_FQDN
+ARG CA_SMTP
+ARG CA_USER
+ARG FTPS_PASV_PORTS
+ARG SECSCAN_ADDR
+#ARG NOTIFY_PROTOCOLS
+ARG IMNOTIFY_ADDRESS
+ARG IMNOTIFY_CHANNEL
+ARG IMNOTIFY_USERNAME
+ARG IMNOTIFY_PASSWD
+ARG EXTERNAL_DOC
+ARG IO_ACCOUNT_EXPIRE
+#ARG PEERS_NOTICE
+#ARG LOGO_CENTER
+#ARG SUPPORT_TEXT
+#ARG PRIVACY_TEXT
+ARG DATASAFETY_LINK
+ARG DATASAFETY_TEXT
+ARG JUPYTER_SERVICES
+ARG JUPYTER_SERVICES_ENABLE_PROXY_HTTPS
+ARG JUPYTER_SERVICES_PROXY_CONFIG
+ARG JUPYTER_SERVICES_DESC
+ARG CLOUD_SERVICES
+ARG CLOUD_SERVICES_DESC
+ARG OPENSSH_VERSION
+ARG DIGEST_SALT
+ARG CRYPTO_SALT
+ARG VGRID_LABEL
+ARG EXTRA_USERPAGE_SCRIPTS
+ARG EXTRA_USERPAGE_STYLES
+ARG GDP_EMAIL_NOTIFY
+ARG GDP_ID_SCRAMBLE
+ARG GDP_PATH_SCRAMBLE
+ARG STORAGE_PROTOCOLS
+ARG WWWSERVE_MAX_BYTES
+ARG SFTP_MAX_SESSIONS
+ARG WSGI_PROCS
+ARG APACHE_WORKER_PROCS
+ARG QUOTA_BACKEND
+ARG QUOTA_LUSTRE_VERSION
+ARG QUOTA_USER_LIMIT
+ARG QUOTA_VGRID_LIMIT
+
+# TODO: do we still need the ~/.local/ wrapper now that update-alternatives run?
+ENV PYTHONPATH=${MIG_ROOT}
+ENV PATH=/home/$USER/.local/bin:$PATH
+# Ensure that the $USER sets it during session start
+RUN echo "PYTHONPATH=${MIG_ROOT}" >> ~/.bash_profile \
+    && echo "export PYTHONPATH" >> ~/.bash_profile
+RUN echo "PATH=$HOME/.local/bin:${PATH}" >> ~/.bash_profile \
+    && echo "export PATH" >> ~/.bash_profile
+
+WORKDIR $MIG_ROOT/mig/install
+
+RUN echo "Designated jupyter services: ${JUPYTER_SERVICES}" && \
+    echo "Designated jupyter services proxy enable https: ${JUPYTER_SERVICES_ENABLE_PROXY_HTTPS}" && \
+    echo "Designated jupyter services proxy config: ${JUPYTER_SERVICES_PROXY_CONFIG}" && \
+    echo "Designated jupyter services descriptions: ${JUPYTER_SERVICES_DESC}" && \
+    echo "Designated cloud services: ${CLOUD_SERVICES}" && \
+    echo "Designated cloud services descriptions: ${CLOUD_SERVICES_DESC}"
+
+RUN mkdir -p ${MIG_ROOT}/.local/bin; \
+    if [ "${PREFER_PYTHON3}" = "True" ]; then \
+      echo "already has python3 as default python"; \
+    else \
+      echo "*** No python2 support here ***" ; exit 1; \
+    fi;
+
+RUN ./generateconfs.py --source=. \
+    --destination=generated-confs \
+    --base_fqdn=$DOMAIN \
+    --public_fqdn=${PUBLIC_DOMAIN} \
+    --public_sec_fqdn=${PUBLIC_SEC_DOMAIN} \
+    --public_alias_fqdn=${PUBLIC_ALIAS_DOMAIN} \
+    --status_alias_fqdn=${STATUS_ALIAS_DOMAIN} \
+    --mig_cert_fqdn=${MIGCERT_DOMAIN} \
+    --ext_cert_fqdn=${EXTCERT_DOMAIN} \
+    --mig_oid_fqdn=${MIGOID_DOMAIN} \
+    --ext_oid_fqdn=${EXTOID_DOMAIN} \
+    --ext_oidc_fqdn=${EXTOIDC_DOMAIN} \
+    --sid_fqdn=${SID_DOMAIN} \
+    --io_fqdn=${IO_DOMAIN} \
+    --user=$USER --group=$GROUP --log_level=${LOG_LEVEL} \
+    --admin_email="${ADMIN_EMAIL}" --admin_list="${ADMIN_LIST}" \
+    --support_email="${SUPPORT_EMAIL}" --smtp_sender="${SMTP_SENDER}" \
+    --smtp_server="${SMTP_SERVER}" \
+    # TODO: expose smtp_port in generateconfs and enable here
+    #--smtp_port="${SMTP_PORT}" \
+    --apache_version=2.4 \
+    --apache_etc=${WEB_DIR} \
+    --apache_run=/var/run/httpd \
+    --apache_lock=/var/lock/subsys/httpd \
+    --apache_log=/var/log/httpd \
+    --openssh_version=${OPENSSH_VERSION} \
+    --mig_code=$MIG_ROOT/mig \
+    --mig_state=$MIG_ROOT/state \
+    --mig_certs=${CERT_DIR} \
+    --hg_path="${HG_PATH}"  \
+    --hgweb_scripts="${HGWEB_SCRIPTS}" \
+    --trac_admin_path="${TRAC_ADMIN_PATH}" \
+    --trac_ini_path="${TRAC_INI_PATH}" \
+    #--trac_id_field=${TRAC_ID_FIELD} \
+    --openid_address=${OPENID_DOMAIN} \
+    --sftp_address=${SFTP_DOMAIN} \
+    --sftp_subsys_address=${SFTP_DOMAIN} \
+    --ftps_address=${FTPS_DOMAIN} \
+    --davs_address=${WEBDAVS_DOMAIN} \
+    --public_http_port=${PUBLIC_HTTP_PORT} --public_https_port=${PUBLIC_HTTPS_PORT} \
+    --mig_oid_port=${MIGOID_HTTPS_PORT} --ext_oid_port=${EXTOID_HTTPS_PORT} \
+    --ext_oidc_port=${EXTOIDC_HTTPS_PORT} --mig_cert_port=${MIGCERT_HTTPS_PORT} \
+    --ext_cert_port=${EXTCERT_HTTPS_PORT} --sid_port=${SID_HTTPS_PORT} \
+    --sftp_port=${SFTP_PORT} --sftp_subsys_port=${SFTP_SUBSYS_PORT} \
+    --sftp_show_port=${SFTP_SHOW_PORT} \
+    --davs_port=${DAVS_PORT} --davs_show_port=${DAVS_SHOW_PORT} \
+    --ftps_ctrl_port=${FTPS_CTRL_PORT} --ftps_ctrl_show_port=${FTPS_CTRL_SHOW_PORT} \
+    --ftps_pasv_ports=${FTPS_PASV_PORTS} \
+    --openid_port=${OPENID_PORT} --openid_show_port=${OPENID_SHOW_PORT} \
+    --io_account_expire=${IO_ACCOUNT_EXPIRE} \
+    --mig_oid_title="${MIG_OID_TITLE}" --ext_oid_title="${EXT_OID_TITLE}" \
+    --mig_oid_provider=${MIG_OID_PROVIDER} \
+    --ext_oid_provider=${EXT_OID_PROVIDER} \
+    --ext_oidc_provider_meta_url=${EXT_OIDC_PROVIDER_META_URL} \
+    --ext_oidc_client_name="${EXT_OIDC_CLIENT_NAME}" \
+    --ext_oidc_client_id="${EXT_OIDC_CLIENT_ID}" \
+    --ext_oidc_scope="${EXT_OIDC_SCOPE}" \
+    --ext_oidc_remote_user_claim="${EXT_OIDC_REMOTE_USER_CLAIM}" \
+    --ext_oidc_pass_claim_as="${EXT_OIDC_PASS_CLAIM_AS}" \
+    --ext_oidc_pkce_method=${EXT_OIDC_PKCE_METHOD} \
+    --ext_oidc_provider_issuer=${EXT_OIDC_PROVIDER_ISSUER} \
+    --ext_oidc_provider_authorization_endpoint=${EXT_OIDC_PROVIDER_AUTHORIZATION_ENDPOINT} \
+    --ext_oidc_provider_token_endpoint=${EXT_OIDC_PROVIDER_TOKEN_ENDPOINT} \
+    --ext_oidc_provider_user_info_endpoint=${EXT_OIDC_PROVIDER_USER_INFO_ENDPOINT} \
+    --ext_oidc_provider_token_endpoint_auth=${EXT_OIDC_PROVIDER_TOKEN_ENDPOINT_AUTH} \
+    --ext_oidc_user_info_token_method=${EXT_OIDC_USER_INFO_TOKEN_METHOD} \
+    --ext_oidc_user_info_signed_response_alg=${EXT_OIDC_USER_INFO_SIGNED_RESPONSE_ALG} \
+    --ext_oidc_cookie_same_site="${EXT_OIDC_COOKIE_SAME_SITE}" \
+    --ext_oidc_pass_cookies="${EXT_OIDC_PASS_COOKIES}" \
+    --ext_oidc_response_mode=${EXT_OIDC_RESPONSE_MODE} \
+    --ext_oidc_provider_verify_cert_files="${EXT_OIDC_PROVIDER_VERIFY_CERT_FILES}" \
+    --ext_oidc_private_key_files="${EXT_OIDC_PRIVATE_KEY_FILES}" \
+    --ext_oidc_public_key_files="${EXT_OIDC_PUBLIC_KEY_FILES}" \
+    --ext_oidc_id_token_encrypted_response_alg=${EXT_OIDC_ID_TOKEN_ENCRYPTED_RESPONSE_ALG} \
+    --ext_oidc_id_token_encrypted_response_enc=${EXT_OIDC_ID_TOKEN_ENCRYPTED_RESPONSE_ENC} \
+    --ext_oidc_rewrite_cookie="${EXT_OIDC_REWRITE_COOKIE}" \
+    --ext_oidc_title="${EXT_OIDC_TITLE}" \
+    --enable_openid=${ENABLE_OPENID} --enable_wsgi=True \
+    --enable_sftp=${ENABLE_SFTP} --enable_sftp_subsys=${ENABLE_SFTP_SUBSYS} \
+    --enable_davs=${ENABLE_DAVS} --enable_ftps=${ENABLE_FTPS} \
+    --enable_sharelinks=${ENABLE_SHARELINKS} --enable_transfers=${ENABLE_TRANSFERS} \
+    --enable_duplicati=${ENABLE_DUPLICATI} --enable_seafile=${ENABLE_SEAFILE} \
+    --seafile_fqdn=${SEAFILE_FQDN} --seafile_ro_access=${SEAFILE_RO_ACCESS} \
+    --enable_sandboxes=${ENABLE_SANDBOXES} --enable_vmachines=${ENABLE_VMACHINES} \
+    --enable_crontab=${ENABLE_CRONTAB} --enable_jobs=${ENABLE_JOBS} \
+    --enable_resources=${ENABLE_RESOURCES} --enable_events=${ENABLE_EVENTS} \
+    --enable_gravatars=${ENABLE_GRAVATARS} --enable_sitestatus=${ENABLE_SITESTATUS} \
+    --status_system_match="${STATUS_SYSTEM_MATCH}" --enable_freeze=${ENABLE_FREEZE} \
+    --permanent_freeze="${PERMANENT_FREEZE}" --freeze_to_tape=${FREEZE_TO_TAPE} \
+    --enable_imnotify=${ENABLE_IMNOTIFY} \
+    --enable_cracklib=${ENABLE_CRACKLIB} --enable_twofactor=${ENABLE_TWOFACTOR} \
+    --enable_twofactor_strict_address=${ENABLE_TWOFACTOR_STRICT_ADDRESS} \
+    --twofactor_auth_apps="${TWOFACTOR_AUTH_APPS}" \
+    --enable_peers=${ENABLE_PEERS} --peers_mandatory=${PEERS_MANDATORY} \
+    --peers_explicit_fields="${PEERS_EXPLICIT_FIELDS}" \
+    --peers_contact_hint="${PEERS_CONTACT_HINT}" \
+    --enable_notify=${ENABLE_NOTIFY} \
+    --enable_workflows=${ENABLE_WORKFLOWS} --enable_hsts=True \
+    --enable_vhost_certs=True --enable_verify_certs=${ENABLE_VERIFY_CERTS} \
+    --enable_jupyter=${ENABLE_JUPYTER} --enable_cloud=${ENABLE_CLOUD} \
+    # TODO: expose additional cloud conf including jumphost key and use here
+    --enable_migadmin=${ENABLE_MIGADMIN} --enable_janitor=${ENABLE_JANITOR} \
+    --enable_gdp=${ENABLE_GDP} --gdp_email_notify=${GDP_EMAIL_NOTIFY} \
+    --gdp_id_scramble=${GDP_ID_SCRAMBLE} --gdp_path_scramble=${GDP_PATH_SCRAMBLE} \
+    --enable_quota=${ENABLE_QUOTA} --quota_backend="${QUOTA_BACKEND}" \
+    --quota_user_limit=${QUOTA_USER_LIMIT} --quota_vgrid_limit=${QUOTA_VGRID_LIMIT} \
+    --storage_protocols="${STORAGE_PROTOCOLS}" \
+    --wwwserve_max_bytes=${WWWSERVE_MAX_BYTES} \
+    --password_policy=${MIG_PASSWORD_POLICY} \
+    --jupyter_services="${JUPYTER_SERVICES}" \
+    --jupyter_services_enable_proxy_https="${JUPYTER_SERVICES_ENABLE_PROXY_HTTPS}" \
+    --jupyter_services_proxy_config="${JUPYTER_SERVICES_PROXY_CONFIG}" \
+    --jupyter_services_desc="${JUPYTER_SERVICES_DESC}" \
+    --cloud_services="${CLOUD_SERVICES}" \
+    --cloud_services_desc="${CLOUD_SERVICES_DESC}" \
+    --prefer_python3=${PREFER_PYTHON3} \
+    --user_clause=User --group_clause=Group \
+    --listen_clause='#Listen' \
+    --serveralias_clause='ServerAlias' --alias_field=email \
+    --dhparams_path="${CERT_DIR}/dhparams.pem" \
+    --daemon_keycert="${CERT_DIR}/combined.pem" \
+    --daemon_keycert_sha256="FILE::${CERT_DIR}/combined.pem.sha256" \
+    --daemon_pubkey="${CERT_DIR}/combined.pub" \
+    --daemon_pubkey_md5="FILE::${CERT_DIR}/combined.pub.md5" \
+    --daemon_pubkey_sha256="FILE::${CERT_DIR}/combined.pub.sha256" \
+    --daemon_pubkey_from_dns=${PUBKEY_FROM_DNS} \
+    --daemon_show_address=${IO_DOMAIN} \
+    --signup_methods="${SIGNUP_METHODS}" \
+    --login_methods="${LOGIN_METHODS}" \
+    --distro=rocky --user_interface="${USER_INTERFACES}" \
+    #--new_user_default_ui=${NEW_USER_DEFAULT_UI} \
+    --skin="${EMULATE_FLAVOR}-${SKIN_SUFFIX}" \
+    --title="${TITLE}" --short_title="${SHORT_TITLE}" \
+    --digest_salt="${DIGEST_SALT}" --crypto_salt="${CRYPTO_SALT}" \
+    --vgrid_label="${VGRID_LABEL}" --peers_permit="${PEERS_PERMIT}" \
+    --vgrid_creators="${VGRID_CREATORS}" --vgrid_managers="${VGRID_MANAGERS}" \
+    --default_vgrid_links="${DEFAULT_VGRID_LINKS}" \
+    --advanced_vgrid_links="${ADVANCED_VGRID_LINKS}" \
+    --auto_add_cert_user=${AUTO_ADD_CERT_USER} \
+    --auto_add_oid_user=${AUTO_ADD_OID_USER} \
+    --auto_add_oidc_user=${AUTO_ADD_OIDC_USER} \
+    --auto_add_filter_fields="${AUTO_ADD_FILTER_FIELDS}" \
+    --auto_add_filter_method=${AUTO_ADD_FILTER_METHOD} \
+    --auto_add_user_permit="${AUTO_ADD_USER_PERMIT}" \
+    --cert_valid_days=${CERT_VALID_DAYS} --oid_valid_days=${OID_VALID_DAYS} \
+    --generic_valid_days=${GENERIC_VALID_DAYS} \
+    --default_menu="${DEFAULT_MENU}" --user_menu="${USER_MENU}" \
+    --ca_fqdn=${CA_FQDN} --ca_smtp=${CA_SMTP} --ca_user=${CA_USER} \
+    --secscan_addr="${SECSCAN_ADDR}" \
+    #--notify_protocols="${NOTIFY_PROTOCOLS}" \
+    --imnotify_address=${IMNOTIFY_ADDRESS} --imnotify_channel=${IMNOTIFY_CHANNEL} \
+    --imnotify_username=${IMNOTIFY_USERNAME} --imnotify_password=${IMNOTIFY_PASSWD} \
+    --external_doc=${EXTERNAL_DOC} \
+    #--peers_notice="${PEERS_NOTICE}" --logo_center="${LOGO_CENTER}" \
+    #--support-text="${SUPPORT_TEXT}" --privacy_text="${PRIVACY_TEXT}" \
+    --datasafety_link="${DATASAFETY_LINK}" --datasafety_text="${DATASAFETY_TEXT}" \
+    --extra_userpage_scripts="${EXTRA_USERPAGE_SCRIPTS}" \
+    --extra_userpage_styles="${EXTRA_USERPAGE_STYLES}" \
+    --sftp_max_sessions=${SFTP_MAX_SESSIONS} \
+    --apache_worker_procs=${APACHE_WORKER_PROCS} --wsgi_procs=${WSGI_PROCS}
+
+RUN cp generated-confs/MiGserver.conf $MIG_ROOT/mig/server/ \
+    && cp generated-confs/static-skin.css $MIG_ROOT/mig/images/ \
+    && cp generated-confs/index.html $MIG_ROOT/state/user_home/
+
+# Site conf for js helpers including status page and auth options on index page
+RUN [ -e "$MIG_ROOT/mig/images/site-conf-${DOMAIN}.js" ] || \
+    cp -a $MIG_ROOT/mig/images/site-conf-${EMULATE_FQDN}.js \
+       $MIG_ROOT/mig/images/site-conf-${DOMAIN}.js
+
+# Add a couple of named pipes for communicating with grid_X daemons
+RUN cd $MIG_ROOT && mkfifo mig/server/server.stdin && mkfifo mig/server/notify.stdin
+
+# Prepare oiddiscover for httpd
+RUN cd $MIG_ROOT && python mig/server/genoiddiscovery.py \
+    > $MIG_ROOT/state/wwwpublic/oiddiscover.xml
+
+# link relevant cloud access helpers into default locations if ENABLE_CLOUD is set here
+# IMPORTANT: the actual cloud access tokens/keys should NEVER enter repos etc.
+# NOTE: openstack client expects details in fixed cloud.yaml file.
+RUN if [ "${ENABLE_CLOUD}" = "True" ]; then \
+        cd $MIG_ROOT ; mkdir -m 0750 -p .config/openstack .ssh ; \
+        [ -n "${CLOUD_ACCESS}" ] || CLOUD_ACCESS="cloud-access.yaml" ; \
+        ln -s ../../state/secrets/${CLOUD_ACCESS} .config/openstack/clouds.yaml ; \
+        [ -n "${CLOUD_JUMPHOST_KEY}" ] || CLOUD_JUMPHOST_KEY="cloud-jumphost-key" ; \ 
+        ln -s ../state/secrets/${CLOUD_JUMPHOST_KEY} .ssh/${CLOUD_JUMPHOST_KEY} ; \
+        ln -s ../state/secrets/${CLOUD_JUMPHOST_KEY}.pub .ssh/${CLOUD_JUMPHOST_KEY}.pub ; \
+        ln -s ${CLOUD_JUMPHOST_KEY} .ssh/id_rsa ; \
+        ln -s ${CLOUD_JUMPHOST_KEY}.pub .ssh/id_rsa.pub ; \
+    fi;
+
+# link relevant py trac ini into default location if no TRAC_INI_PATH is set here
+RUN if [ -n "${TRAC_ADMIN_PATH}" -a -z "${TRAC_INI_PATH}" ]; then \
+        cd $MIG_ROOT ; \
+        if [ "${PREFER_PYTHON3}" = "True" ]; then \
+            ln -s trac-py3.ini mig/server/trac.ini; \
+        else \
+            ln -s trac-py2.ini mig/server/trac.ini; \
+        fi; \
+    fi;
+
+
+#------------------------- next stage -----------------------------#
+FROM --platform=linux/$ARCH install_mig AS setup_mig_configs
+ARG DOMAIN
+ARG PUBLIC_DOMAIN
+ARG MIGCERT_DOMAIN
+ARG EXTCERT_DOMAIN
+ARG MIGOID_DOMAIN
+ARG EXTOID_DOMAIN
+ARG EXTOIDC_DOMAIN
+ARG SID_DOMAIN
+ARG EMULATE_FLAVOR
+ARG EMULATE_FQDN
+ARG ENABLE_SELF_SIGNED_CERTS
+ARG ENABLE_OPENID
+ARG WITH_PY3
+ARG PREFER_PYTHON3
+ARG ENABLE_LOGROTATE
+ARG LOGROTATE_MIGRID
+ARG ENABLE_GDP
+ARG WITH_GIT
+ARG MIG_GIT_BRANCH
+ARG ENABLE_QUOTA
+ARG ENABLE_FREEZE
+ARG QUOTA_BACKEND
+ARG QUOTA_LUSTRE_VERSION
+ARG OS_CA_CERT_SOURCE_PATH
+
+USER root
+
+# Sftp subsys config
+RUN cp generated-confs/sshd_config-MiG-sftp-subsys /etc/ssh/ \
+    && chown 0:0 /etc/ssh/sshd_config-MiG-sftp-subsys
+
+# PAM and NSS setup for sftpsubsys login to work
+RUN cd $MIG_ROOT/mig/src/libpam-mig \
+    && make && make install
+RUN cd $MIG_ROOT/mig/src/libnss-mig \
+    && make && make install
+# Python sslsession C-extension or sslkeylog is needed to avoid repeat SSL/TLS
+# negotiation in WebDAVS
+# NOTE: both require openssl-devel to build and sslkeylog is only supported
+# on python 2.7.9+ and 3. The sslsession module generally builds but fails at
+# runtime when used with OpenSSL-1.1+, however.
+RUN if [ "${WITH_PY3}" = "True" ]; then \
+      cd $MIG_ROOT/mig/src/sslsession \
+      && pip3 install --no-cache-dir . ; \
+    fi;
+
+RUN cp generated-confs/libnss_mig.conf /etc/ \
+    #&& cp /etc/pam.d/sshd /etc/pam.d/sshd.backup \
+    && cp generated-confs/pam-sshd /etc/pam.d/sshd \
+    #&& cp /etc/nsswitch.conf /etc/nsswitch.conf.backup
+    && cp generated-confs/nsswitch.conf /etc/
+
+# Adjust paramiko to reduce log noise from scans if matching patch is available
+RUN cd $MIG_ROOT/mig/src/paramiko \
+    && if [ -e Makefile ]; then make patch PLATFORM=el9 ; fi
+
+RUN chmod 755 generated-confs/envvars \
+    && chmod 755 generated-confs/httpd.conf
+
+# Apache base confs - the systemd one and maybe sysconfig is not really used
+RUN cp generated-confs/MiG.conf $WEB_DIR/conf.d/ \
+    && cp generated-confs/httpd.conf $WEB_DIR/ \
+    && cp generated-confs/mimic-deb.conf $WEB_DIR/conf/httpd.conf \
+    && cp generated-confs/envvars /etc/sysconfig/httpd \
+    && cp generated-confs/apache2.service /lib/systemd/system/httpd.service
+
+# Disable missing mod auth openid in this case
+RUN if [ "$ENABLE_OPENID" = "True" ]; then \
+        echo "Keep mod_auth_openid in apache"; \
+    else \
+        echo "Disable missing mod_auth_openid in apache" && \
+	sed -i 's@LoadModule authopenid_mod@#LoadModule authopenid_mod@g' $WEB_DIR/conf/httpd.conf; \
+    fi
+
+# Apache Jupyter inclusion confs
+RUN mkdir -p $WEB_DIR/conf.extras.d/ \
+    && cp generated-confs/MiG-jupyter-def.conf $WEB_DIR/conf.extras.d \
+    && cp generated-confs/MiG-jupyter-openid.conf $WEB_DIR/conf.extras.d \
+    && cp generated-confs/MiG-jupyter-oidc.conf $WEB_DIR/conf.extras.d \
+    && cp generated-confs/MiG-jupyter-proxy.conf $WEB_DIR/conf.extras.d \
+    && cp generated-confs/MiG-jupyter-rewrite.conf $WEB_DIR/conf.extras.d
+
+# Root confs
+RUN cp generated-confs/apache2.conf $WEB_DIR/ \
+    && cp generated-confs/ports.conf $WEB_DIR/ \
+    && cp generated-confs/envvars $WEB_DIR/
+
+# Disable certificate check for OID if self-signed certs
+RUN if [ "$ENABLE_SELF_SIGNED_CERTS" = "True" ]; then \
+        sed -i '/\/server.ca.pem/ a SSLProxyCheckPeerName off' $WEB_DIR/conf.d/MiG.conf \
+        && sed -i '/SSLProxyCheckPeerName off/ a SSLProxyCheckPeerCN off' \
+        $WEB_DIR/conf.d/MiG.conf; \
+    fi
+
+# Front page
+RUN [ "${EMULATE_FQDN}" = "${DOMAIN}" ] || \
+	cp -a $MIG_ROOT/state/wwwpublic/index-${EMULATE_FQDN}.html \
+		$MIG_ROOT/state/wwwpublic/index-${DOMAIN}.html
+
+RUN ln -s index-${DOMAIN}.html $MIG_ROOT/state/wwwpublic/index.html && \
+    ln -s about-${EMULATE_FQDN}.html $MIG_ROOT/state/wwwpublic/about-snippet.html && \
+    ln -s support-${EMULATE_FQDN}.html $MIG_ROOT/state/wwwpublic/support-snippet.html && \
+    ln -s tips-${EMULATE_FQDN}.html $MIG_ROOT/state/wwwpublic/tips-snippet.html && \
+    ln -s terms-${EMULATE_FQDN}.html $MIG_ROOT/state/wwwpublic/terms-snippet.html && \
+    ln -s terms-${EMULATE_FQDN}.html $MIG_ROOT/state/wwwpublic/terms.html && \
+    ln -s site-conf-${DOMAIN}.js $MIG_ROOT/mig/images/site-conf.js && \
+    # Make an empty template for status popup and status page to use.
+    # For inspiration on how to use it please refer to the samples at
+    # https://github.com/ucphhpc/migrid-ucph-sites/tree/main/state/wwwpublic
+    echo '[]' > $MIG_ROOT/state/wwwpublic/status-events-${DOMAIN}.json && \
+    ln -s status-events-${DOMAIN}.json $MIG_ROOT/state/wwwpublic/status-events.json && \
+    ln -s status-dynamic.html $MIG_ROOT/state/wwwpublic/status.html && \
+    # Optional site helpers which we symlink in order to use them if they exist
+    ln -s cookie-policy-${DOMAIN}.pdf \
+        $MIG_ROOT/state/wwwpublic/cookie-policy.pdf && \
+    ln -s site-privacy-policy-${DOMAIN}.pdf \
+        $MIG_ROOT/state/wwwpublic/site-privacy-policy.pdf && \
+    ln -s security-${DOMAIN}.txt \
+        $MIG_ROOT/state/wwwpublic/.well-known/security.txt && \
+    ln -s security-${DOMAIN}.txt.asc \
+        $MIG_ROOT/state/wwwpublic/.well-known/security.txt.asc && \
+    ln -s security-pub-keys-${DOMAIN}.txt \
+        $MIG_ROOT/state/wwwpublic/.well-known/security-pub-keys.txt && \
+    ln -s security-disclosure-policy-${DOMAIN}.txt \
+        $MIG_ROOT/state/wwwpublic/.well-known/security-disclosure-policy.txt && \
+    # Reuse site helpers from EMULATE_FQDN if no site versions exist
+    if [ ! -e "$MIG_ROOT/state/wwwpublic/cookie-policy-${DOMAIN}.pdf" ]; then \
+        ln -s cookie-policy-${EMULATE_FQDN}.pdf \
+            $MIG_ROOT/state/wwwpublic/cookie-policy-${DOMAIN}.pdf ; \
+    fi && \
+    if [ ! -e "$MIG_ROOT/state/wwwpublic/site-privacy-policy-${DOMAIN}.pdf" ]; then \
+        ln -s site-privacy-policy-${EMULATE_FQDN}.pdf \
+            $MIG_ROOT/state/wwwpublic/site-privacy-policy-${DOMAIN}.pdf ; \
+    fi && \
+    if [ ! -e "$MIG_ROOT/state/wwwpublic/.well-known/security-${DOMAIN}.txt" ]; then \
+        ln -s security-${EMULATE_FQDN}.txt \
+            $MIG_ROOT/state/wwwpublic/.well-known/security-${DOMAIN}.txt ; \
+    fi && \
+    if [ ! -e "$MIG_ROOT/state/wwwpublic/.well-known/security-${DOMAIN}.txt.asc" ]; then \
+        ln -s security-${EMULATE_FQDN}.txt.asc \
+            $MIG_ROOT/state/wwwpublic/.well-known/security-${DOMAIN}.txt.asc ; \
+    fi && \
+    if [ ! -e "$MIG_ROOT/state/wwwpublic/.well-known/security-pub-keys-${DOMAIN}.txt" ]; then \
+        ln -s security-pub-keys-${EMULATE_FQDN}.txt \
+            $MIG_ROOT/state/wwwpublic/.well-known/security-pub-keys-${DOMAIN}.txt ; \
+    fi && \
+    if [ ! -e "$MIG_ROOT/state/wwwpublic/.well-known/security-disclosure-policy-${DOMAIN}.txt" ]; then \
+        ln -s security-disclosure-policy-${EMULATE_FQDN}.txt \
+            $MIG_ROOT/state/wwwpublic/.well-known/security-disclosure-policy-${DOMAIN}.txt ; \
+    fi && \
+    chown -R $USER:$GROUP $MIG_ROOT/state/wwwpublic/*.html
+
+# TODO: improve this very crude and hard-coded translation
+# Replace index.html redirects to instance domains
+RUN sed -i -e "s@https://ext\.${EMULATE_FQDN}@https://${MIGOID_DOMAIN}@g;s@https://oid\.${EMULATE_FQDN}@https://${EXTOID_DOMAIN}@g;s@https://oidc\.${EMULATE_FQDN}@https://${EXTOIDC_DOMAIN}@g;s@https://${EMULATE_FQDN}@https://${PUBLIC_DOMAIN}@g;s@https://cert\.${EMULATE_FQDN}@https://${EXTCERT_DOMAIN}@g;s@https://sid\.${EMULATE_FQDN}@https://${SID_DOMAIN}@g" $MIG_ROOT/state/wwwpublic/index-${DOMAIN}.html
+
+# Various cron jobs e.g. to clean stale state and inform migoid account users near expiry
+RUN chmod 755 generated-confs/{migstateclean,mignotifyexpire,migerrors,migacctexpire} \
+    && cp generated-confs/{migstateclean,mignotifyexpire,migerrors} /etc/cron.daily/ \
+    && cp generated-confs/migacctexpire /etc/cron.monthly/
+RUN if [  -e "generated-confs/migstats" ]; then \
+    chmod 755 generated-confs/migstats \
+    && cp generated-confs/migstats /etc/cron.weekly/ ; \
+    fi;
+RUN if [ "${ENABLE_FREEZE}" = "True" ]; then \
+      chmod 755 generated-confs/{migimportdoi,migindexdoi,migverifyarchives} \
+      && cp generated-confs/{migimportdoi,migindexdoi} /etc/cron.daily/ \
+      && cp generated-confs/migverifyarchives /etc/cron.hourly/ ; \
+    fi;
+
+# Logrotate config if enabled
+RUN if [ "${ENABLE_LOGROTATE}" = "True" ]; then \
+      if [ "${LOGROTATE_MIGRID}" = "True" ]; then \
+        cp generated-confs/logrotate-migrid /etc/logrotate.d/migrid; \
+      fi; \
+    else \
+        [ ! -f /etc/cron.daily/logrotate ] || rm -f /etc/cron.daily/logrotate; \
+    fi;
+
+# Init scripts
+RUN cp generated-confs/migrid-init.d-rh /etc/init.d/migrid
+
+WORKDIR $MIG_ROOT
+
+# Prepare default conf.d
+RUN mv $WEB_DIR/conf.d/autoindex.conf $WEB_DIR/conf.d/autoindex.conf.disabled \
+    && mv $WEB_DIR/conf.d/ssl.conf $WEB_DIR/conf.d/ssl.conf.disabled \
+    && mv $WEB_DIR/conf.d/userdir.conf $WEB_DIR/conf.d/userdir.conf.disabled \
+    && mv $WEB_DIR/conf.d/welcome.conf $WEB_DIR/conf.d/welcome.conf.disabled
+
+# Add generated certificate to trust store
+RUN update-ca-trust force-enable \
+    && cp ${CERT_DIR}/combined.pem ${OS_CA_CERT_SOURCE_PATH}/ \
+    && update-ca-trust extract
+
+# rsyslog: Disable systemd and enable /dev/log
+# NOTE: rsyslog.conf module loading changed between centos 7 and centos/rocky 8
+# https://projectatomic.io/blog/2014/09/running-syslog-within-a-docker-container/
+# New format and no listen.conf
+RUN sed -i -e 's/^module(load="imjournal"/#module(load="imjournal"/g' \
+	-e 's/       UsePid="system"/#       UsePid="system"/g' \
+        -e 's/       StateFile="imjournal.state"/#       StateFile="imjournal.state"/g' \
+        -e 's/       FileCreateMode="0644" # Set the access permissions for the state file/#       FileCreateMode="0644" # Set the access permissions for the state file/g' \
+	-e 's/SysSock.Use="off"/SysSock.Use="on"/g' /etc/rsyslog.conf
+
+# Enable GDP log 
+# NOTE: on RHEL clones the default messages log will also get a copy unless we
+#       explicitly exclude local0 there with local0.none in the line:
+#*.info;mail.none;authpriv.none;cron.none               /var/log/messages
+RUN if [ "${ENABLE_GDP}" = "True" ]; then \
+      GDP_LOG_DIR="${MIG_ROOT}/state/log" ; \
+      GDP_LOG_PATH="${GDP_LOG_DIR}/gdp.log" ; \
+      [ ! -d "${GDP_LOG_DIR}" ] \
+        && mkdir ${GDP_LOG_DIR} \
+        && chmod 700 ${GDP_LOG_DIR} ; \
+      [ ! -f "${GDP_LOG_PATH}" ] \
+        && touch ${GDP_LOG_PATH} \
+        && chmod 600 ${GDP_LOG_PATH}; \
+      if ! grep -q "${GDP_LOG_PATH}" /etc/rsyslog.conf ; then \
+        sed -i -E "s@^(\*\.info;.*;cron\.none) @\1;local0.none @g" \
+                /etc/rsyslog.conf ; \
+        echo "" >> /etc/rsyslog.conf ; \
+        echo "# MiG GDP messages" >> /etc/rsyslog.conf ; \
+        echo "local0.*               ${GDP_LOG_PATH}" >> /etc/rsyslog.conf ; \
+      fi; \
+    fi;
+
+# Install pylustrequota
+# NOTE: Requires py3 and git next branch
+RUN if [ "${ENABLE_QUOTA}" = "True" ] \
+            && [ "${PREFER_PYTHON3}" = "True" ] \
+            && [ "${WITH_GIT}" = "True" ] \
+            && [ "${MIG_GIT_BRANCH}" = "next" ]; then \
+        if [ "${QUOTA_BACKEND}" = "lustre" ] \
+            || [ "${QUOTA_BACKEND}" = "lustre-gocryptfs" ]; then \
+            echo "install pylustrequota" \
+            && dnf update -y \
+            && dnf --enablerepo=crb install -y \
+            python3-devel.x86_64 \
+            libtool.x86_64 \
+            kernel-devel.x86_64 \
+            kernel-abi-stablelists \
+            flex.x86_64 \
+            bison.x86_64 \
+            keyutils-libs-devel.x86_64 \
+            libmount-devel.x86_64 \
+            libnl3-devel.x86_64 \
+            libyaml-devel \
+            krb5-devel.x86_64 \
+            && dnf clean all \
+            && rm -fr /var/cache/dnf \
+            && cd ${MIG_ROOT}/mig/src/pylustrequota \
+            && git clone https://github.com/lustre/lustre-release \
+            && cd ${MIG_ROOT}/mig/src/pylustrequota/lustre-release \
+            && git checkout ${QUOTA_LUSTRE_VERSION} \
+            && sh ./autogen.sh \
+            && ./configure --disable-server --enable-quota --enable-utils --enable-gss \
+            && make undef.h \
+            && cd ${MIG_ROOT}/mig/src/pylustrequota/lustre-release/libcfs/libcfs \
+            && make libcfs.la \
+            && cd ${MIG_ROOT}/mig/src/pylustrequota/lustre-release/lnet/utils/lnetconfig \
+            && make liblnetconfig.la \
+            && cd ${MIG_ROOT}/mig/src/pylustrequota/lustre-release/lustre/utils \
+            && make liblustreapi.la \
+            && cd ${MIG_ROOT}/mig/src/pylustrequota \
+            && python3 -m pip install --use-pep517 . \
+            && rm -rf ${MIG_ROOT}/mig/src/pylustrequota/lustre-release; \
+        fi; \
+    fi;
+#------------------------- next stage -----------------------------#
+FROM --platform=linux/$ARCH setup_mig_configs AS start_mig
+ARG DOMAIN
+
+# Reap defuncted/orphaned processes
+# IMPORTANT: always verify gpg signature / use verified checksum in downloads!
+ARG TINI_VERSION=v0.18.0
+ARG TINI_CHECKSUM=sha256:12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855
+ARG TINI_GPG_KEY=0527A9B7
+# NOTE: hadolint awaits https://github.com/hadolint/language-docker/pull/92 in
+#       an actual release so it will currectly fail hard on the checksum arg.
+#       Rely solely on explicit gpg signature verification for the time being.
+#ADD --checksum=${TINI_CHECKSUM} https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc /tini.asc
+# NOTE: some build environments with strict firewalling may not allow e.g. hkp.
+#       For robustness try different methods in turn until key import succeeds.
+RUN for key in ${TINI_GPG_KEY}; do \
+      gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" || \
+      gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys "$key" || \
+      gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys "$key" ; \
+    done && \
+    if ! gpg --verify /tini.asc /tini ; then \
+      echo "FATAL: failed to verify tini binary"; \
+      exit 1 ; \
+    fi
+RUN chmod +x /tini
+ENTRYPOINT ["/tini", "--"]
+
+# NOTE: it's recommended to use COPY over ADD except when URL/unpack is needed
+COPY docker-entry.sh /app/docker-entry.sh
+COPY apply-hotfixes.sh /app/apply-hotfixes.sh
+COPY migrid-httpd.env /app/migrid-httpd.env
+COPY migrid-httpd-init.sh /app/migrid-httpd-init.sh
+COPY apache-init-helper /etc/init.d/apache-minimal
+# NOTE: inherit explicit LANG set above for apache and migrid services
+RUN sed "s/#LANG=.*/LANG=${LANG}/g" /app/migrid-httpd-init.sh > /etc/sysconfig/apache-minimal
+RUN grep LANG /etc/sysconfig/apache-minimal > /etc/sysconfig/migrid
+COPY rsyslog-init-helper /etc/init.d/rsyslog-minimal
+RUN chown $USER:$GROUP /app/docker-entry.sh \
+    && chmod +x /app/docker-entry.sh /app/apply-hotfixes.sh
+
+USER root
+WORKDIR /app
+
+# EXPOSE is not important but keep in sync with active ports for the record
+EXPOSE 80 443 444 445 446 447 448 449 2222 4443 8021 22222
+
+CMD ["bash", "/app/docker-entry.sh"]
+LABEL MIGRID=false

--- a/Dockerfile.rocky10
+++ b/Dockerfile.rocky10
@@ -237,7 +237,7 @@ ARG CLOUD_SERVICES=""
 ARG CLOUD_SERVICES_DESC="{}"
 
 #------------------------- first stage -----------------------------#
-FROM --platform=linux/$ARCH rockylinux:10 AS init
+FROM --platform=linux/$ARCH rockylinux/rockylinux:10 AS init
 ARG UID
 ARG GID
 ARG DOMAIN

--- a/Dockerfile.rocky10
+++ b/Dockerfile.rocky10
@@ -455,11 +455,7 @@ RUN if [ "${ENABLE_GDP}" = "True" ]; then \
 RUN if [ "$ENABLE_OPENID" = "True" ]; then \
         # Install python3-openid from pip as it is not available in Rocky10
         pip3 install --no-cache-dir python3-openid; \
-    fi
-# TODO: fix apache mod auth openid build and enable next
-#RUN if [ "$ENABLE_OPENID" = "True" ]; then \
-RUN if [ "$DEBUG_BROKEN_MOD_AUTH_OPENID_BUILD" = "True" ]; then \
-        echo "building mod_auth_openid from centos7 source rpm" \
+        echo "prepare building mod_auth_openid from epel7 source rpm" \
         && dnf update -y \
         && dnf install -y gcc-c++ \
             rpm-build \
@@ -470,7 +466,8 @@ RUN if [ "$DEBUG_BROKEN_MOD_AUTH_OPENID_BUILD" = "True" ]; then \
             httpd-devel \
             libcurl-devel \
             libtidy-devel \
-            pcre-devel \
+            # NOTE: Rocky10 has pcre2-devel but libopkele demands pcre-devel
+            #pcre-devel \
             openssl-devel \
             libtool \
             sqlite-devel \
@@ -483,11 +480,23 @@ RUN if [ "$DEBUG_BROKEN_MOD_AUTH_OPENID_BUILD" = "True" ]; then \
         && rm -fr /var/cache/dnf \
         # NOTE: add EPEL CentOS 7 repos here but completely disabled
         # NOTE: rocky9+ switched from explicit version to variable expansion
-        #      as in 10 - > $releasever
+        #         as in 10 - > $releasever
+        #       rocky10 repo sources also need pruning of
+        #         epel${releasever_minor:+-z} -> epel
         && cat /etc/yum.repos.d/epel.repo | \
-                sed 's/\[epel/\[epel7/g;s/\(epel[a-z-]*\)-10/\1-7/g;s/\$releasever/7/g;s/enabled=1/enabled=0/g' \
-                > /etc/yum.repos.d/epel7.repo \
-        && echo "build libopkele from centos7 source rpm" \
+                sed 's/\[epel/\[epel7/g;s/epel\${releasever_minor.*}/epel/g;s/\$releasever/7/g;s/enabled=1/enabled=0/g' \
+                > /etc/yum.repos.d/epel7.repo ; \
+        # TODO: instead add disabled rocky9 repo too and only use for these?
+        echo "install old Rocky 9 pcre packages for libopkele build" \
+        && dnf install -y \
+            https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/pcre-utf16-8.44-4.el9.x86_64.rpm \
+            https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/pcre-utf32-8.44-4.el9.x86_64.rpm \
+            https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/pcre-cpp-8.44-4.el9.x86_64.rpm \
+            https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pcre-8.44-4.el9.x86_64.rpm \
+            https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/pcre-devel-8.44-4.el9.x86_64.rpm \
+        && dnf clean all \
+        && rm -fr /var/cache/dnf \
+        && echo "install libopkele from epel7 source rpm" \
         # NOTE: avoid hard-coded version using yumdownloader from yum-utils
         && yumdownloader -y --enablerepo=epel7-source --source --resolve --destdir /root/rpmbuild/SRPMS libopkele \
         && rpm -ivh /root/rpmbuild/SRPMS/libopkele-*.src.rpm \
@@ -502,7 +511,7 @@ RUN if [ "$DEBUG_BROKEN_MOD_AUTH_OPENID_BUILD" = "True" ]; then \
         && rm -f /root/rpmbuild/RPMS/*/libopkele-*debug*.rpm \
         #&& dnf erase -y 'libopkele-*' \
         && dnf install -y /root/rpmbuild/RPMS/*/libopkele-*.rpm \
-        && echo "install mod_auth_openid centos7 source rpm" \
+        && echo "install mod_auth_openid epel7 source rpm" \
         #&& rpm -e --nodeps mod_auth_openid \
         # NOTE: avoid hard-coded version using yumdownloader from yum-utils
         && yumdownloader -y --enablerepo=epel7-source --source --resolve --destdir /root/rpmbuild/SRPMS mod_auth_openid \

--- a/Dockerfile.rocky10
+++ b/Dockerfile.rocky10
@@ -399,8 +399,6 @@ RUN echo "install py3 deps" \
     # NOTE: openid mod not available on Rocky10 so install with pip if enabled
     #python3-openid \
     python3-pyOpenSSL \
-    # NOTE: lxml and libxslt-devel required to build python-openid2
-    python3-lxml \
     python3-pycurl \
     python3-PyYAML \
     # NOTE: we can just use native Cryptography and typing-extensions here
@@ -794,9 +792,6 @@ RUN if [ "${ENABLE_CLOUD}" = "True" ]; then \
         pip3 install --no-cache-dir "openstacksdk==${OPENSTACKSDK_VERSION_OVERRIDE}" ; \
       fi; \
     fi;
-
-# OpenID support in python (python-openid2 for py3) - use alternative from dnf 
-#RUN pip3 install --no-cache-dir python-openid2;
 
 # Modules required by grid_events.py and grid_cron.py
 # TODO: eliminate scandir now that it is built into os.scandir

--- a/Dockerfile.rocky10
+++ b/Dockerfile.rocky10
@@ -762,7 +762,8 @@ USER root
 RUN pip3 install --no-cache-dir jsonrpclib-pelix pysendfile iso3166
 
 # We still have legacy dependency on future which is not in Rocky10
-RUN pip3 install --no-cache-dir future
+# IMPORTANT: sftpsubsys relies on 'future' so prefix must be /usr here.
+RUN pip3 install --no-cache-dir --prefix=$(python3-config --prefix) future
 
 # NOTE: recent paramiko is required for modern host key algo
 RUN if [ "${ENABLE_SFTP}" = "True" -o "${ENABLE_SFTP_SUBSYS}" = "True" ]; then \

--- a/Dockerfile.rocky10
+++ b/Dockerfile.rocky10
@@ -439,7 +439,7 @@ RUN if [ "${ENABLE_GDP}" = "True" ]; then \
       xorg-x11-server-Xvfb \
       # NOTE: wkhtmltopdf not yet built for Rocky10 - try almalinux9 rpm
       https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-3/wkhtmltox-0.12.6.1-3.almalinux9.x86_64.rpm \
-      # TODO: is compat-openssl11.x86_64 still needed by Rocky9 version of wkhtmltopdf?
+      # TODO: is compat-openssl11.x86_64 still needed by Rocky9 version of wkhtmltopdf ?
       #compat-openssl11.x86_64 \
       && dnf clean all \
       && rm -fr /var/cache/dnf; \
@@ -806,13 +806,13 @@ RUN if [ "${ENABLE_CRONTAB}" = "True" -o "${ENABLE_EVENTS}" = "True" ]; then \
 
 # Modules required by grid_webdavs
 RUN if [ "${ENABLE_DAVS}" = "True" ]; then \
-      # IMPORTANT: use at least 4.1 here to avoid a potential security issue 
-      # https://github.com/mar10/wsgidav/security/advisories/GHSA-xx6g-jj35-pxjv
+      # IMPORTANT: use at least 4.3.5 here to avoid a potential security issue
+      # https://github.com/mar10/wsgidav/security/advisories/GHSA-wm65-64rq-rh8r
       # IMPORTANT: use cheroot before 10.0.1 as it currently crashes webdavs
       #            One can trigger the crash with a simple testssl.sh run
       # TODO: investigate if the problem is in cheroot, wsgidav or migrid.
       # Prefer sslkeylog as session tracking helper in webdavs daemon.
-      pip3 install --no-cache-dir 'cheroot<10.0.1' 'wsgidav>=4.1.0'; \
+      pip3 install --no-cache-dir 'cheroot<10.0.1' 'wsgidav>=4.3.5'; \
       pip3 install --no-cache-dir sslkeylog ; \
     fi;
 
@@ -894,15 +894,24 @@ WORKDIR $MIG_ROOT
 USER $USER
 
 # Install and configure MiG
+# IMPORTANT: git does NOT really enforce any branch and revision match!
+#            We init to track upstream branch and then checkout rev to at least
+#            get any divergence warnings, but it happily switches to rev even
+#            if from a completely different branch. We show last log as well to
+#            help identify actual revision.
 # NOTE: git refuses to clone into non-empty dir - use tmp
 
-RUN git clone ${MIG_GIT_REPO} migrid.git && \
+RUN echo "Clone migrid: ${MIG_GIT_REPO} ${MIG_GIT_BRANCH} ${MIG_GIT_REV}" && \
+    git clone ${MIG_GIT_REPO} migrid.git && \
     cd migrid.git && \
     git checkout -B ${MIG_GIT_BRANCH} --track origin/${MIG_GIT_BRANCH} && \
-    git checkout ${MIG_GIT_REV} && cd .. && \
+    git checkout -B ${MIG_GIT_BRANCH} ${MIG_GIT_REV} && \
+    git log -n 1 && \
+    cd .. && \
     rsync -a migrid.git/ ./ && \
     rm -rf migrid.git/ && \
-    echo "migrid version: ${MIG_GIT_REPO} ${MIG_GIT_BRANCH} ${MIG_GIT_REV}" > ./active-migrid-version.txt
+    echo "migrid version: ${MIG_GIT_REPO} ${MIG_GIT_BRANCH} ${MIG_GIT_REV}" > \
+        ./active-migrid-version.txt
 
 
 #------------------------- next stage -----------------------------#
@@ -1209,12 +1218,15 @@ RUN ./generateconfs.py --source=. \
     # TODO: expose additional cloud conf including jumphost key and use here
     --enable_migadmin=${ENABLE_MIGADMIN} --enable_janitor=${ENABLE_JANITOR} \
     --enable_gdp=${ENABLE_GDP} --gdp_email_notify=${GDP_EMAIL_NOTIFY} \
-    --gdp_id_scramble=${GDP_ID_SCRAMBLE} --gdp_path_scramble=${GDP_PATH_SCRAMBLE} \
+    --gdp_id_scramble=${GDP_ID_SCRAMBLE} \
+    --gdp_path_scramble=${GDP_PATH_SCRAMBLE} \
     --enable_quota=${ENABLE_QUOTA} --quota_backend="${QUOTA_BACKEND}" \
     --quota_update_interval=${QUOTA_UPDATE_INTERVAL} \
     --enable_antislowloris=${ENABLE_ANTISLOWLORIS} \
-    --quota_user_limit=${QUOTA_USER_LIMIT} --quota_vgrid_limit=${QUOTA_VGRID_LIMIT} \
-    --enable_accounting=${ENABLE_ACCOUNTING} --accounting_update_interval=${ACCOUNTING_UPDATE_INTERVAL} \
+    --quota_user_limit=${QUOTA_USER_LIMIT} \
+    --quota_vgrid_limit=${QUOTA_VGRID_LIMIT} \
+    --enable_accounting=${ENABLE_ACCOUNTING} \
+    --accounting_update_interval=${ACCOUNTING_UPDATE_INTERVAL} \
     --storage_protocols="${STORAGE_PROTOCOLS}" \
     --wwwserve_max_bytes=${WWWSERVE_MAX_BYTES} \
     --password_policy=${MIG_PASSWORD_POLICY} \

--- a/Dockerfile.rocky10
+++ b/Dockerfile.rocky10
@@ -1,7 +1,7 @@
 # Default ARG values which may be overriden in build command with
 # docker-compose build --build-arg KEY=VAL
 #  as in 
-# make init && make build ARGS="--build-arg MIG_SVN_REV=HEAD"
+# make init && make build ARGS="--build-arg MIG_GIT_REV=HEAD"
 #  or using
 # docker-compose build
 # with .env file in place
@@ -56,8 +56,6 @@ ARG FTPS_CTRL_PORT=8021
 ARG FTPS_CTRL_SHOW_PORT=21
 ARG OPENID_PORT=8443
 ARG OPENID_SHOW_PORT=443
-ARG MIG_SVN_REPO=https://svn.code.sf.net/p/migrid/code/trunk
-ARG MIG_SVN_REV=HEAD
 ARG MIG_GIT_REPO=https://github.com/ucphhpc/migrid-sync.git
 # NOTE: next branch is needed for python3 support
 ARG MIG_GIT_BRANCH=next
@@ -96,13 +94,12 @@ ARG ENABLE_DUPLICATI=True
 ARG ENABLE_SEAFILE=False
 ARG SEAFILE_FQDN=
 ARG SEAFILE_RO_ACCESS=False
-ARG ENABLE_SANDBOXES=False
-ARG ENABLE_VMACHINES=False
 ARG ENABLE_CRONTAB=True
 ARG ENABLE_JOBS=True
 ARG ENABLE_RESOURCES=True
 ARG ENABLE_EVENTS=True
 ARG ENABLE_GRAVATARS=True
+ARG ENABLE_PYTEST=False
 ARG ENABLE_SITESTATUS=True
 ARG STATUS_SYSTEM_MATCH="ANY"
 ARG ENABLE_FREEZE=False
@@ -127,6 +124,8 @@ ARG ENABLE_TWOFACTOR_STRICT_ADDRESS=False
 ARG TWOFACTOR_AUTH_APPS=""
 ARG ENABLE_PEERS=True
 ARG ENABLE_QUOTA=False
+ARG ENABLE_ACCOUNTING=False
+ARG ENABLE_ANTISLOWLORIS=False
 ARG PEERS_MANDATORY=False
 ARG PEERS_EXPLICIT_FIELDS=""
 ARG PEERS_CONTACT_HINT="authorized to invite you as peer"
@@ -148,9 +147,6 @@ ARG UPGRADE_OIDC_AUTH_MOD_SRC=""
 # NOTE: paramiko is a bit dated in OS repo - allow optional upgrade
 ARG UPGRADE_PARAMIKO=False
 ARG PUBKEY_FROM_DNS=False
-# NOTE: python2 support is gone on rocky9+
-ARG WITH_PY3=True
-ARG PREFER_PYTHON3=True
 ARG SIGNUP_METHODS=migoid
 ARG LOGIN_METHODS=migoid
 ARG USER_INTERFACES=V3
@@ -196,7 +192,7 @@ ARG IMNOTIFY_ADDRESS=""
 ARG IMNOTIFY_CHANNEL=""
 ARG IMNOTIFY_USERNAME=""
 ARG IMNOTIFY_PASSWD=""
-ARG EXTERNAL_DOC="https://sourceforge.net/p/migrid/wiki"
+ARG EXTERNAL_DOC="https://github.com/ucphhpc/migrid-sync/wiki"
 ARG IO_ACCOUNT_EXPIRE="False"
 # TODO: expose and enable these UI vars
 #ARG PEERS_NOTICE=""
@@ -207,7 +203,6 @@ ARG DATASAFETY_LINK=""
 ARG DATASAFETY_TEXT=""
 # NOTE: no python2 here and we already get 4.3+ for python3
 ARG MODERN_WSGIDAV=False
-ARG WITH_GIT=False
 ARG OPENSSH_VERSION=7.4
 ARG VGRID_LABEL=VGrid
 ARG DIGEST_SALT="AUTO"
@@ -223,12 +218,14 @@ ARG SFTP_MAX_SESSIONS=32
 ARG WSGI_PROCS=25
 ARG APACHE_WORKER_PROCS=256
 ARG QUOTA_BACKEND=""
+ARG QUOTA_UPDATE_INTERVAL=3600
 ARG QUOTA_USER_LIMIT=1099511627776
 ARG QUOTA_VGRID_LIMIT=1099511627776
 ARG QUOTA_LUSTRE_VERSION="2.15.4"
 ARG QUOTA_LUSTRE_BASE="/dev/null"
 ARG QUOTA_GOCRYPTFS_XRAY="/dev/null"
 ARG QUOTA_GOCRYPTFS_SOCK="/dev/null"
+ARG ACCOUNTING_UPDATE_INTERVAL=3600
 
 # Jupyter Arguments
 ARG JUPYTER_SERVICES=""
@@ -270,17 +267,13 @@ ARG SFTP_SUBSYS_PORT
 ARG DAVS_PORT
 ARG FTPS_CTRL_PORT
 ARG OPENID_PORT
-#ARG MIG_SVN_REPO
-#ARG MIG_SVN_REV
 #ARG MIG_GIT_REPO
 #ARG MIG_GIT_BRANCH
 #ARG MIG_GIT_REV
 #ARG EMULATE_FLAVOR
 #ARG EMULATE_FQDN
-ARG WITH_PY3
 ARG JUPYTER_SERVICES
 ARG CLOUD_SERVICES
-#ARG WITH_GIT
 
 RUN echo "*** BEGIN Build variables ***" && \
     echo "UID and GID: $UID $GID" && \
@@ -294,11 +287,9 @@ RUN echo "*** BEGIN Build variables ***" && \
     "${MIGCERT_HTTPS_PORT} ${EXTCERT_HTTPS_PORT}" \
     "${SID_HTTPS_PORT} ${SFTP_PORT} ${SFTP_SUBSYS_PORT}" \
     "${FTPS_CTRL_PORT} ${DAVS_PORT} ${OPENID_PORT}" && \
-    #echo "MiG svn repo and revision: $MIG_SVN_REPO $MIG_SVN_REV" && \
-    echo "Enable git checkout & repo : $WITH_GIT $MIG_GIT_REPO" && \
-    echo "MiG git branch & revision:  $MIG_GIT_BRANCH $MIG_GIT_REV" && \
+    echo "MiG git repo: $MIG_GIT_REPO" && \
+    echo "MiG git branch & revision: $MIG_GIT_BRANCH $MIG_GIT_REV" && \
     echo "Emulate flavor & fqdn: $EMULATE_FLAVOR $EMULATE_FQDN" && \
-    echo "Enable python3 support: $WITH_PY3" && \
     #echo "Designated jupyter services: $JUPYTER_SERVICES" && \
     #echo "Designated cloud services: $CLOUD_SERVICES" && \
     echo "*** END Build variables ***"
@@ -314,8 +305,6 @@ ARG UPGRADE_OIDC_CJOSE_SRC
 ARG UPGRADE_OIDC_AUTH_MOD_SRC
 ARG UPGRADE_PARAMIKO
 ARG ENABLE_CLOUD
-ARG WITH_PY3
-ARG PREFER_PYTHON3
 ARG UID
 ARG GID
 ARG SMTP_SERVER
@@ -332,7 +321,7 @@ COPY shell-aliases.sh /etc/profile.d/
 # https://superuser.com/questions/784451/centos-on-docker-how-to-install-doc-files
 RUN sed -i '/nodocs/d' /etc/dnf/dnf.conf
 
-# NOTE: Enable crb repo by default on rocky9 for cracklib-devel, sshfs, ...
+# NOTE: Enable crb repo by default on rocky9+ for cracklib-devel, sshfs, ...
 RUN dnf update -y \
     && dnf install -y epel-release dnf-plugins-core \
     && dnf config-manager --enable crb \
@@ -362,6 +351,7 @@ RUN dnf update -y \
     mod_auth_openidc \
     tzdata \
     initscripts \
+    # NOTE: svn is still needed for trac plugin install from svn+https
     svn \
     git \
     vim \
@@ -371,10 +361,10 @@ RUN dnf update -y \
     mercurial \
     openssh-server \
     openssh-clients \
+    openssl \
     rsyslog \
     rsyslog-gnutls \
     lsof \
-    # NOTE: python2 support is gone on rocky9+
     # NOTE: generally install cracklib from pip as yum/dnf doesn't have it
     #cracklib-python \
     cracklib-devel \
@@ -385,68 +375,60 @@ RUN dnf update -y \
     fail2ban \
     ipset \
     wget \
+    gnupg \
     patch \
-    esmtp \
+    # NOTE: esmtp is not available for Rocky10, try msmtp instead
+    msmtp \
     && dnf clean all \
     && rm -fr /var/cache/dnf
 
-RUN if [ "${WITH_PY3}" = "True" ]; then \
-      echo "install py3 deps" \
-      && dnf update -y \
-      && dnf install -y \
-      python3-pip \
-      python3-devel \
-      python3-mod_wsgi \
-      python3-enchant \
-      #python3-jsonrpclib \
-      python3-requests \
-      python3-psutil \
-      python3-email-validator \
-      python3-future \
-      python3-cffi \
-      python3-openid \
-      python3-pyOpenSSL \
-      # NOTE: lxml and libxslt-devel required to build python-openid2
-      python3-lxml \
-      python3-pycurl \
-      python3-PyYAML \
-      # NOTE: we can just use native Cryptography and typing-extensions here
-      python3-cryptography \
-      python3-typing-extensions \
-      # Patch python3-openid until our pull request makes it to the Rocky repo
-      && echo "Pull python3 openid patch from own repo" \
-      && wget -q -O /tmp/python3-openid-assoc_handle.patch.diff https://raw.githubusercontent.com/ucphhpc/docker-migrid/master/patches/python3-openid-assoc_handle.patch.diff \
-      && patch -p 0 /usr/lib/python3.9/site-packages/openid/server/server.py < /tmp/python3-openid-assoc_handle.patch.diff \
-      && rm -f /tmp/python3-openid-assoc_handle.patch.diff \
-      # NOTE: only install default paramiko if upgrade not requested
-      && [ "${UPGRADE_PARAMIKO}" = "True" ] || dnf install -y python3-paramiko \
-      # NOTE: only install default openstack client if upgrade not requested
-      && [ "${ENABLE_CLOUD}" != "True" ] || dnf install -y python3-openstackclient \
-      && dnf clean all \
-      && rm -fr /var/cache/dnf; \
-    else \
-      echo "no py3 deps"; \
-    fi;
+RUN echo "install py3 deps" \
+    && dnf update -y \
+    && dnf install -y \
+    python3-pip \
+    python3-devel \
+    python3-mod_wsgi \
+    python3-enchant \
+    #python3-jsonrpclib \
+    python3-requests \
+    python3-psutil \
+    python3-email-validator \
+    # NOTE: future mod not available on Rocky10 so install with pip
+    #python3-future \
+    python3-cffi \
+    # NOTE: openid mod not available on Rocky10 so install with pip if enabled
+    #python3-openid \
+    python3-pyOpenSSL \
+    # NOTE: lxml and libxslt-devel required to build python-openid2
+    python3-lxml \
+    python3-pycurl \
+    python3-PyYAML \
+    # NOTE: we can just use native Cryptography and typing-extensions here
+    python3-cryptography \
+    python3-typing-extensions \
+    # NOTE: only install default paramiko if upgrade not requested
+    && [ "${UPGRADE_PARAMIKO}" = "True" ] || dnf install -y python3-paramiko \
+    # NOTE: only install default openstack client if upgrade not requested
+    && [ "${ENABLE_CLOUD}" != "True" ] || dnf install -y python3-openstackclient \
+    && dnf clean all \
+    && rm -fr /var/cache/dnf;
 
-# Containers have esmtp installed by default but we explicitly include it above
+# TODO: test if this dumb search/replace of old esmtp setup works
+# Containers have msmtp installed by default but we explicitly include it above
 # and configure it for host SMTP delivery for cronjobs etc to be able to route
 # mail outside containers.
 RUN if [ -n "${SMTP_SERVER}" ]; then \
       [ -z "${SMTP_PORT}" ] && SMTP_PORT=25; \
-      echo "# Simple SMTP setup to route all local mail to host SMTP" > /etc/esmtprc \
-      && echo "hostname ${SMTP_SERVER}:${SMTP_PORT}" >> /etc/esmtprc \
-      && echo "qualifydomain ${DOMAIN}" >> /etc/esmtprc \
-      && echo "force reverse_path %u@${DOMAIN}" >> /etc/esmtprc ; \
+      echo "# Simple SMTP setup to route all local mail to host SMTP" > /etc/msmtprc \
+      && echo "hostname ${SMTP_SERVER}:${SMTP_PORT}" >> /etc/msmtprc \
+      && echo "qualifydomain ${DOMAIN}" >> /etc/msmtprc \
+      && echo "force reverse_path %u@${DOMAIN}" >> /etc/msmtprc ; \
     fi
 
 # NOTE: python extensions libpam and libnss need matching python-config
-RUN if [ "${PREFER_PYTHON3}" = "True" ]; then \
-      echo "set up py3 as default python and python-config" && \
-      update-alternatives --install /usr/bin/python python /usr/bin/python3 10; \
-      update-alternatives --install /usr/bin/python-config python-config /usr/bin/python3-config 10; \
-    else \
-      echo "*** No python2 support here ***" ; exit 1; \
-    fi;
+RUN echo "set up py3 as default python and python-config" && \
+    update-alternatives --install /usr/bin/python python /usr/bin/python3 10; \
+    update-alternatives --install /usr/bin/python-config python-config /usr/bin/python3-config 10;
 
 
 # Install GDP dependencies
@@ -454,19 +436,16 @@ RUN if [ "${ENABLE_GDP}" = "True" ]; then \
       echo "install GDP deps" \
       && dnf update -y \
       && dnf install -y \
-      # NOTE: python2 support is gone on rocky9+
       xorg-x11-server-Xvfb \
-      # NOTE: wkhtmltopdf not yet build for Rocky9 
-      https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox-0.12.6-1.centos8.x86_64.rpm \
-      # NOTE: compat-openssl11.x86_64 is needed by Rocky8 version of wkhtmltopdf 
-      compat-openssl11.x86_64 \
+      # NOTE: wkhtmltopdf not yet built for Rocky10 - try almalinux9 rpm
+      https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-3/wkhtmltox-0.12.6.1-3.almalinux9.x86_64.rpm \
+      # TODO: is compat-openssl11.x86_64 still needed by Rocky9 version of wkhtmltopdf?
+      #compat-openssl11.x86_64 \
       && dnf clean all \
       && rm -fr /var/cache/dnf; \
-      if [ "${WITH_PY3}" = "True" ]; then \
-         echo "install py3 deps" && \
-         pip3 install --no-cache-dir xvfbwrapper && \
-	     pip3 install --no-cache-dir pdfkit; \
-      fi; \
+      echo "install py3 deps" && \
+      pip3 install --no-cache-dir xvfbwrapper && \
+      pip3 install --no-cache-dir pdfkit; \
     else \
       echo "no GDP deps"; \
     fi;
@@ -474,6 +453,12 @@ RUN if [ "${ENABLE_GDP}" = "True" ]; then \
 
 # Build Apache OpenID (provided by epel for centos7) 
 RUN if [ "$ENABLE_OPENID" = "True" ]; then \
+        # Install python3-openid from pip as it is not available in Rocky10
+        pip3 install --no-cache-dir python3-openid; \
+    fi
+# TODO: fix apache mod auth openid build and enable next
+#RUN if [ "$ENABLE_OPENID" = "True" ]; then \
+RUN if [ "$DEBUG_BROKEN_MOD_AUTH_OPENID_BUILD" = "True" ]; then \
         echo "building mod_auth_openid from centos7 source rpm" \
         && dnf update -y \
         && dnf install -y gcc-c++ \
@@ -497,10 +482,10 @@ RUN if [ "$ENABLE_OPENID" = "True" ]; then \
         && dnf clean all \
         && rm -fr /var/cache/dnf \
         # NOTE: add EPEL CentOS 7 repos here but completely disabled
-        # NOTE: rocky9 switched from explicit version to variable expansion
-        #      as in 9 - > $releasever
+        # NOTE: rocky9+ switched from explicit version to variable expansion
+        #      as in 10 - > $releasever
         && cat /etc/yum.repos.d/epel.repo | \
-                sed 's/\[epel/\[epel7/g;s/\(epel[a-z-]*\)-9/\1-7/g;s/\$releasever/7/g;s/enabled=1/enabled=0/g' \
+                sed 's/\[epel/\[epel7/g;s/\(epel[a-z-]*\)-10/\1-7/g;s/\$releasever/7/g;s/enabled=1/enabled=0/g' \
                 > /etc/yum.repos.d/epel7.repo \
         && echo "build libopkele from centos7 source rpm" \
         # NOTE: avoid hard-coded version using yumdownloader from yum-utils
@@ -535,16 +520,17 @@ RUN if [ "$ENABLE_OPENID" = "True" ]; then \
     fi;
 
 
-# Upgrade mod_auth_openidc from upstream github packages if requested - mainly needed for rhel/centos7
-# https://stackoverflow.com/questions/68742362/how-to-install-mod-auth-openidc-on-rhel-7
+# Upgrade mod_auth_openidc from upstream github packages if requested - mainly
+# needed for most recent security fixes.
 # The module requires a recent cjose library version. Packaged versions are
 # also available on the upstream releases page under the 2.4.0 release Assets.
-# Version 2.4.12.1+ is needed to support the OIDCPassClaimsAs encoding setting in apache conf
+# Version 2.4.12.1+ is needed to support the OIDCPassClaimsAs encoding setting
+# in apache conf.
 RUN echo "UPGRADE_MOD_AUTH_OPENIDC: $UPGRADE_MOD_AUTH_OPENIDC"
 RUN if [ "$UPGRADE_MOD_AUTH_OPENIDC" = "True" ]; then \
         if [ -z "${UPGRADE_OIDC_AUTH_MOD_SRC}" ]; then \
 		echo "upgrading mod_auth_openidc from upstream release package"; \
-		UPGRADE_OIDC_AUTH_MOD_SRC="https://github.com/OpenIDC/mod_auth_openidc/releases/download/v2.4.16.11/mod_auth_openidc-2.4.16.11-1.el9.x86_64.rpm"; \
+		UPGRADE_OIDC_AUTH_MOD_SRC="https://github.com/OpenIDC/mod_auth_openidc/releases/download/v2.4.20.2/mod_auth_openidc-2.4.20.2-1.el10.x86_64.rpm"; \
 	else \
 		echo "upgrading mod_auth_openidc from ${UPGRADE_OIDC_AUTH_MOD_SRC}"; \
 	fi; \ 
@@ -553,7 +539,7 @@ RUN if [ "$UPGRADE_MOD_AUTH_OPENIDC" = "True" ]; then \
 		#echo "installing cjose dependency from OS package"; \
 		#UPGRADE_OIDC_CJOSE_SRC="cjose"; \
 		echo "upgrading cjose from upstream release package"; \
-		UPGRADE_OIDC_CJOSE_SRC="https://github.com/OpenIDC/cjose/releases/download/v0.6.2.3/cjose-0.6.2.3-1.el9.x86_64.rpm"; \
+		UPGRADE_OIDC_CJOSE_SRC="https://github.com/OpenIDC/cjose/releases/download/v0.6.2.7/cjose-0.6.2.7-1.el10.x86_64.rpm"; \
 	else \
 		echo "upgrading cjose from ${UPGRADE_OIDC_CJOSE_SRC}"; \
 	fi; \
@@ -711,11 +697,6 @@ RUN if [ ! -e "${CERT_DIR}/.persistent" ]; then \
                [ -L "$domain" ] || ln -s MiG/${WILDCARD_DOMAIN} $domain; \
        done ; fi
 
-# Upgrade pip3 is only required for cryptography from pip - irrelevant here
-#RUN if [ "${WITH_PY3}" = "True" ]; then \
-#      python3 -m pip install --no-cache-dir -U 'pip'; \
-#    fi;
-
 # NOTE: make certs as mig user
 WORKDIR $MIG_ROOT
 USER $USER
@@ -734,7 +715,9 @@ RUN mkdir -p MiG-certificates \
 USER root
 WORKDIR /tmp
 # Copy in any external certificates that should be part of the OS trusted ca bundle
-RUN update-ca-trust force-enable
+# TODO: we used 'force-enable' on Rocky9 but unsupported on Rocky10 - does this work?
+#RUN update-ca-trust force-enable
+RUN update-ca-trust
 COPY external-certificates/ ${OS_CA_CERT_SOURCE_PATH}/
 RUN update-ca-trust extract
 
@@ -744,10 +727,19 @@ USER $USER
 #------------------------- next stage -----------------------------#
 FROM --platform=linux/$ARCH setup_security AS mig_dependencies
 ARG DOMAIN
-ARG WITH_PY3
 ARG MODERN_WSGIDAV
 ARG UPGRADE_PARAMIKO
+ARG ENABLE_SFTP
+ARG ENABLE_SFTP_SUBSYS
 ARG ENABLE_CLOUD
+ARG ENABLE_CRONTAB
+ARG ENABLE_EVENTS
+ARG ENABLE_DAVS
+ARG ENABLE_FTPS
+ARG ENABLE_CRACKLIB
+ARG ENABLE_PYTEST
+ARG ENABLE_TWOFACTOR
+ARG ENABLE_WORKFLOWS
 ARG OPENSTACKSDK_VERSION_OVERRIDE
 ARG TRAC_ADMIN_PATH
 
@@ -756,14 +748,16 @@ USER root
 
 # Prepare py dependencies not in dnf or just outdated there
 
-# NOTE: use jsonrpclib and pysendfile from pip for py3 here
-RUN if [ "${WITH_PY3}" = "True" ]; then \
-      pip3 install --no-cache-dir 'jsonrpclib<0.2' pysendfile; \
-    fi;
+# NOTE: use maintained jsonrpclib fork and pysendfile from pip for py3 here
+#       and iso3166 for smart country selection
+RUN pip3 install --no-cache-dir jsonrpclib-pelix pysendfile iso3166
+
+# We still have legacy dependency on future which is not in Rocky10
+RUN pip3 install --no-cache-dir future
 
 # NOTE: recent paramiko is required for modern host key algo
-RUN if [ "${UPGRADE_PARAMIKO}" = "True" ]; then \
-      if [ "${WITH_PY3}" = "True" ]; then \
+RUN if [ "${ENABLE_SFTP}" = "True" -o "${ENABLE_SFTP_SUBSYS}" = "True" ]; then \
+      if [ "${UPGRADE_PARAMIKO}" = "True" ]; then \
         # NOTE: a newer setuptools MAY be needed and setuptools_rust MUST be 
         #       installed separately here for whatever reason.
         # IMPORTANT: sftp_subsys.py is explicitly called with 'python -s' to
@@ -777,26 +771,15 @@ RUN if [ "${UPGRADE_PARAMIKO}" = "True" ]; then \
         # Additional NOTE: paramiko version 3.x introduces several changes
         # that in particular improve the SFTP download performance.
         # At the time of writing, the RHEL/Rocky 10 EPEL repo provides 3.5,
-        # which we use as a version baseline to mimic.
-        # However, combining that with recent bcrypt versions in the 4.x
-        # series leads to import errors in mod_wsgi caused by the usage of
-        # sub-interpreters as highlighted at
-        # https://github.com/PyO3/pyo3/blob/main/guide/src/migration.md#each-pymodule-can-now-only-be-initialized-once-per-process
-        # with further explanation at
-        # https://bugzilla.redhat.com/show_bug.cgi?id=2255688 and
-        # https://github.com/PyO3/pyo3/issues/3451
-        # So we explicitly cap the bcrypt version to the latest 3.2 one,
-        # which coincides with the default Rocky version, btw.
-        pip3 install --no-cache-dir --prefix=$(python3-config --prefix) 'paramiko>=3.5' 'bcrypt<4'; \
+        # which we used as a version baseline to mimic in Rocky9 but skip now.
+        # TODO: test and drop bcrypt version cap if issues are solved here
+        pip3 install --no-cache-dir --prefix=$(python3-config --prefix) paramiko; \
       fi; \
     fi;
 
 # NOTE: openstackclient is available in dnf here, but sdk may be requested
 #       e.g. to work around version 1.0.0 breaking floating IP assignment
 RUN if [ "${ENABLE_CLOUD}" = "True" ]; then \
-      #if [ "${WITH_PY3}" = "True" ]; then \
-      #  pip3 install --no-cache-dir python-openstackclient; \
-      #fi; \
       if [ -n "${OPENSTACKSDK_VERSION_OVERRIDE}" ]; then \
         pip3 install --no-cache-dir "openstacksdk==${OPENSTACKSDK_VERSION_OVERRIDE}" ; \
       fi; \
@@ -805,28 +788,27 @@ RUN if [ "${ENABLE_CLOUD}" = "True" ]; then \
 # OpenID support in python (python-openid2 for py3) - use alternative from dnf 
 #RUN pip3 install --no-cache-dir python-openid2;
 
-# Modules required by grid_events.py
-RUN if [ "${WITH_PY3}" = "True" ]; then \
+# Modules required by grid_events.py and grid_cron.py
+# TODO: eliminate scandir now that it is built into os.scandir
+RUN if [ "${ENABLE_CRONTAB}" = "True" -o "${ENABLE_EVENTS}" = "True" ]; then \
       pip3 install --no-cache-dir watchdog scandir; \
     fi;
 
 # Modules required by grid_webdavs
-RUN if [ "${WITH_PY3}" = "True" ]; then \
+RUN if [ "${ENABLE_DAVS}" = "True" ]; then \
       # IMPORTANT: use at least 4.1 here to avoid a potential security issue 
       # https://github.com/mar10/wsgidav/security/advisories/GHSA-xx6g-jj35-pxjv
       # IMPORTANT: use cheroot before 10.0.1 as it currently crashes webdavs
       #            One can trigger the crash with a simple testssl.sh run
       # TODO: investigate if the problem is in cheroot, wsgidav or migrid.
+      # Prefer sslkeylog as session tracking helper in webdavs daemon.
       pip3 install --no-cache-dir 'cheroot<10.0.1' 'wsgidav>=4.1.0'; \
-    fi;
-# Prefer sslkeylog as session tracking helper in webdavs daemon.
-RUN if [ "${WITH_PY3}" = "True" ]; then \
       pip3 install --no-cache-dir sslkeylog ; \
     fi;
 
 # Modules required by grid_ftps
 # NOTE: relies on pyOpenSSL and Cryptography from yum/dnf for now
-RUN if [ "${WITH_PY3}" = "True" ]; then \
+RUN if [ "${ENABLE_FTPS}" = "True" ]; then \
       pip3 install --no-cache-dir pyftpdlib; \
     fi;
 
@@ -834,23 +816,22 @@ RUN if [ "${WITH_PY3}" = "True" ]; then \
 # IMPORTANT: install in main python site-packages to work with 'python -s'
 #            Otherwise sftpsubsys will fail to import it because the /usr/local
 #            dir used as prefix by default in pip is outside sys.path
-RUN if [ "${WITH_PY3}" = "True" ]; then \
+RUN if [ "${ENABLE_CRACKLIB}" = "True" ]; then \
       pip3 install --no-cache-dir --prefix=$(python3-config --prefix) cracklib; \
     fi;
 
-# Module required to run pytests
-RUN if [ "${WITH_PY3}" = "True" ]; then \
-      pip3 install --no-cache-dir pytest; \
+# Module for pytests but unwanted in production and conflicts with TracTags
+RUN if [ "${ENABLE_PYTEST}" = "True" ]; then \
+      if [ -n "${TRAC_ADMIN_PATH}" ]; then \
+        echo "*** TracTags is incompatible with pytest ***" ; exit 1; \
+      else \
+        pip3 install --no-cache-dir pytest; \
+      fi; \
     fi;
 
 # Modules required by 2FA
-RUN if [ "${WITH_PY3}" = "True" ]; then \
+RUN if [ "${ENABLE_TWOFACTOR}" = "True" ]; then \
       pip3 install --no-cache-dir pyotp; \
-    fi;
-
-# Modules required for smart country selection
-RUN if [ "${WITH_PY3}" = "True" ]; then \
-      pip3 install --no-cache-dir iso3166; \
     fi;
 
 # Modules required for email validation (already available in yum/dnf for python3)
@@ -862,7 +843,9 @@ RUN if [ "${WITH_PY3}" = "True" ]; then \
 # Modules required for Trac integration 
 RUN if [ -n "${TRAC_ADMIN_PATH}" ]; then \
       echo "install Trac and plugins" \
-      && pip3 install --no-cache-dir Trac TracWikiPrint TracGraphviz TracFullBlog TracWikiCssPlugin \
+      && pip3 install --no-cache-dir Trac TracWikiPrint TracFullBlog TracWikiCssPlugin \
+      # NOTE: this plugin would be nice but it has a huge dep footprint
+      #&& pip3 install --no-cache-dir TracGraphviz \
       # IMPORTANT: Mercurial plugin is required for our repos and only recent
       #            stable releases support current python and Trac versions.
       #            We need 1.0.0.11+ for the default Python 3 and Trac-1.6.
@@ -873,13 +856,18 @@ RUN if [ -n "${TRAC_ADMIN_PATH}" ]; then \
       #&& pip3 install --no-cache-dir https://trac-hacks.org/svn/tracwysiwygplugin/0.12
       # NOTE: install more recent dev versions of those with Trac-1.6+ support
       # latest tag https://github.com/trac-hacks/tracstats/releases/tag/v0.6.1 is pre 1.6
-      && pip3 install --no-cache-dir https://github.com/trac-hacks/tracstats/archive/refs/heads/master.zip ; \
+      && pip3 install --no-cache-dir https://github.com/trac-hacks/tracstats/archive/refs/heads/master.zip \
+      # latest tag https://trac-hacks.org/svn/tagsplugin/tags/0.12 is pre 1.6
+      && pip3 install --no-cache-dir svn+https://trac-hacks.org/svn/tagsplugin/trunk ; \
     else \
       echo "no Trac deps"; \
     fi;
 
 # Modules required for workflows
-RUN if [ "${WITH_PY3}" = "True" ]; then \
+# NOTE: the bleach library used by nbconvert is abandoned
+#       https://github.com/jupyter/nbconvert/issues/2289
+#       and has security issues, too, so only install if explicitly requested.
+RUN if [ "${ENABLE_WORKFLOWS}" = "True" ]; then \
       pip3 install --no-cache-dir nbformat nbconvert papermill; \
     fi;
 
@@ -887,13 +875,9 @@ RUN if [ "${WITH_PY3}" = "True" ]; then \
 FROM --platform=linux/$ARCH mig_dependencies AS download_mig
 LABEL MIGRID=true
 ARG DOMAIN
-ARG MIG_SVN_REPO
-ARG MIG_SVN_REV
-ARG WITH_GIT
 ARG MIG_GIT_REPO
 ARG MIG_GIT_BRANCH
 ARG MIG_GIT_REV
-ARG PREFER_PYTHON3
 ARG MODERN_WSGIDAV
 
 WORKDIR $MIG_ROOT
@@ -902,23 +886,13 @@ USER $USER
 # Install and configure MiG
 # NOTE: git refuses to clone into non-empty dir - use tmp
 
-RUN if [ "$WITH_GIT" = "True" ]; then \
-      git clone ${MIG_GIT_REPO} migrid.git && \
-        cd migrid.git && \
-        git checkout -B ${MIG_GIT_BRANCH} --track origin/${MIG_GIT_BRANCH} && \
-        git checkout ${MIG_GIT_REV} && cd .. && \
-        rsync -a migrid.git/ ./ && \
-        rm -rf migrid.git/ && \
-	echo "migrid version: ${MIG_GIT_REPO} ${MIG_GIT_BRANCH} ${MIG_GIT_REV}" > ./active-migrid-version.txt; \
-    else \
-      svn checkout -r ${MIG_SVN_REV} ${MIG_SVN_REPO} . && \
-	echo "migrid version: ${MIG_SVN_REPO} trunk ${MIG_SVN_REV}" > ./active-migrid-version.txt; \
-    fi;
-
-# NOTE: we manually need to enable modern grid_webdavs.py here for now.
-#       Replace any existing symlink with one to the 3.x script.
-RUN rm -f ${MIG_ROOT}/mig/server/grid_webdavs.py ; \
-    ln -s grid_webdavs-3.x.py ${MIG_ROOT}/mig/server/grid_webdavs.py;
+RUN git clone ${MIG_GIT_REPO} migrid.git && \
+    cd migrid.git && \
+    git checkout -B ${MIG_GIT_BRANCH} --track origin/${MIG_GIT_BRANCH} && \
+    git checkout ${MIG_GIT_REV} && cd .. && \
+    rsync -a migrid.git/ ./ && \
+    rm -rf migrid.git/ && \
+    echo "migrid version: ${MIG_GIT_REPO} ${MIG_GIT_BRANCH} ${MIG_GIT_REV}" > ./active-migrid-version.txt
 
 
 #------------------------- next stage -----------------------------#
@@ -998,8 +972,6 @@ ARG ENABLE_DUPLICATI
 ARG ENABLE_SEAFILE
 ARG SEAFILE_FQDN
 ARG SEAFILE_RO_ACCESS
-ARG ENABLE_SANDBOXES
-ARG ENABLE_VMACHINES
 ARG ENABLE_CRONTAB
 ARG ENABLE_JOBS
 ARG ENABLE_RESOURCES
@@ -1027,12 +999,13 @@ ARG ENABLE_TWOFACTOR_STRICT_ADDRESS
 ARG TWOFACTOR_AUTH_APPS
 ARG ENABLE_PEERS
 ARG ENABLE_QUOTA
+ARG ENABLE_ACCOUNTING
+ARG ENABLE_ANTISLOWLORIS
 ARG PEERS_MANDATORY
 ARG PEERS_EXPLICIT_FIELDS
 ARG PEERS_CONTACT_HINT
 ARG MIG_PASSWORD_POLICY
 ARG PUBKEY_FROM_DNS
-ARG PREFER_PYTHON3
 ARG SIGNUP_METHODS
 ARG LOGIN_METHODS
 ARG USER_INTERFACES
@@ -1104,18 +1077,16 @@ ARG SFTP_MAX_SESSIONS
 ARG WSGI_PROCS
 ARG APACHE_WORKER_PROCS
 ARG QUOTA_BACKEND
-ARG QUOTA_LUSTRE_VERSION
+ARG QUOTA_UPDATE_INTERVAL
 ARG QUOTA_USER_LIMIT
 ARG QUOTA_VGRID_LIMIT
+ARG QUOTA_LUSTRE_VERSION
+ARG ACCOUNTING_UPDATE_INTERVAL
 
-# TODO: do we still need the ~/.local/ wrapper now that update-alternatives run?
 ENV PYTHONPATH=${MIG_ROOT}
-ENV PATH=/home/$USER/.local/bin:$PATH
 # Ensure that the $USER sets it during session start
 RUN echo "PYTHONPATH=${MIG_ROOT}" >> ~/.bash_profile \
     && echo "export PYTHONPATH" >> ~/.bash_profile
-RUN echo "PATH=$HOME/.local/bin:${PATH}" >> ~/.bash_profile \
-    && echo "export PATH" >> ~/.bash_profile
 
 WORKDIR $MIG_ROOT/mig/install
 
@@ -1125,13 +1096,6 @@ RUN echo "Designated jupyter services: ${JUPYTER_SERVICES}" && \
     echo "Designated jupyter services descriptions: ${JUPYTER_SERVICES_DESC}" && \
     echo "Designated cloud services: ${CLOUD_SERVICES}" && \
     echo "Designated cloud services descriptions: ${CLOUD_SERVICES_DESC}"
-
-RUN mkdir -p ${MIG_ROOT}/.local/bin; \
-    if [ "${PREFER_PYTHON3}" = "True" ]; then \
-      echo "already has python3 as default python"; \
-    else \
-      echo "*** No python2 support here ***" ; exit 1; \
-    fi;
 
 RUN ./generateconfs.py --source=. \
     --destination=generated-confs \
@@ -1216,7 +1180,6 @@ RUN ./generateconfs.py --source=. \
     --enable_sharelinks=${ENABLE_SHARELINKS} --enable_transfers=${ENABLE_TRANSFERS} \
     --enable_duplicati=${ENABLE_DUPLICATI} --enable_seafile=${ENABLE_SEAFILE} \
     --seafile_fqdn=${SEAFILE_FQDN} --seafile_ro_access=${SEAFILE_RO_ACCESS} \
-    --enable_sandboxes=${ENABLE_SANDBOXES} --enable_vmachines=${ENABLE_VMACHINES} \
     --enable_crontab=${ENABLE_CRONTAB} --enable_jobs=${ENABLE_JOBS} \
     --enable_resources=${ENABLE_RESOURCES} --enable_events=${ENABLE_EVENTS} \
     --enable_gravatars=${ENABLE_GRAVATARS} --enable_sitestatus=${ENABLE_SITESTATUS} \
@@ -1238,7 +1201,10 @@ RUN ./generateconfs.py --source=. \
     --enable_gdp=${ENABLE_GDP} --gdp_email_notify=${GDP_EMAIL_NOTIFY} \
     --gdp_id_scramble=${GDP_ID_SCRAMBLE} --gdp_path_scramble=${GDP_PATH_SCRAMBLE} \
     --enable_quota=${ENABLE_QUOTA} --quota_backend="${QUOTA_BACKEND}" \
+    --quota_update_interval=${QUOTA_UPDATE_INTERVAL} \
+    --enable_antislowloris=${ENABLE_ANTISLOWLORIS} \
     --quota_user_limit=${QUOTA_USER_LIMIT} --quota_vgrid_limit=${QUOTA_VGRID_LIMIT} \
+    --enable_accounting=${ENABLE_ACCOUNTING} --accounting_update_interval=${ACCOUNTING_UPDATE_INTERVAL} \
     --storage_protocols="${STORAGE_PROTOCOLS}" \
     --wwwserve_max_bytes=${WWWSERVE_MAX_BYTES} \
     --password_policy=${MIG_PASSWORD_POLICY} \
@@ -1248,7 +1214,6 @@ RUN ./generateconfs.py --source=. \
     --jupyter_services_desc="${JUPYTER_SERVICES_DESC}" \
     --cloud_services="${CLOUD_SERVICES}" \
     --cloud_services_desc="${CLOUD_SERVICES_DESC}" \
-    --prefer_python3=${PREFER_PYTHON3} \
     --user_clause=User --group_clause=Group \
     --listen_clause='#Listen' \
     --serveralias_clause='ServerAlias' --alias_field=email \
@@ -1327,11 +1292,10 @@ RUN if [ "${ENABLE_CLOUD}" = "True" ]; then \
 # link relevant py trac ini into default location if no TRAC_INI_PATH is set here
 RUN if [ -n "${TRAC_ADMIN_PATH}" -a -z "${TRAC_INI_PATH}" ]; then \
         cd $MIG_ROOT ; \
-        if [ "${PREFER_PYTHON3}" = "True" ]; then \
-            ln -s trac-py3.ini mig/server/trac.ini; \
-        else \
-            ln -s trac-py2.ini mig/server/trac.ini; \
-        fi; \
+        ln -s trac-py3.ini mig/server/trac.ini; \
+        [ ! -e "mig/images/site-logo-${EMULATE_FQDN}.png" ] || \
+        cp -a "mig/images/site-logo-${EMULATE_FQDN}.png" \
+            mig/images/site-logo.png ; \
     fi;
 
 
@@ -1349,12 +1313,10 @@ ARG EMULATE_FLAVOR
 ARG EMULATE_FQDN
 ARG ENABLE_SELF_SIGNED_CERTS
 ARG ENABLE_OPENID
-ARG WITH_PY3
-ARG PREFER_PYTHON3
+ARG ENABLE_DAVS
 ARG ENABLE_LOGROTATE
 ARG LOGROTATE_MIGRID
 ARG ENABLE_GDP
-ARG WITH_GIT
 ARG MIG_GIT_BRANCH
 ARG ENABLE_QUOTA
 ARG ENABLE_FREEZE
@@ -1378,7 +1340,7 @@ RUN cd $MIG_ROOT/mig/src/libnss-mig \
 # NOTE: both require openssl-devel to build and sslkeylog is only supported
 # on python 2.7.9+ and 3. The sslsession module generally builds but fails at
 # runtime when used with OpenSSL-1.1+, however.
-RUN if [ "${WITH_PY3}" = "True" ]; then \
+RUN if [ "${ENABLE_DAVS}" = "True" ]; then \
       cd $MIG_ROOT/mig/src/sslsession \
       && pip3 install --no-cache-dir . ; \
     fi;
@@ -1528,8 +1490,10 @@ RUN mv $WEB_DIR/conf.d/autoindex.conf $WEB_DIR/conf.d/autoindex.conf.disabled \
     && mv $WEB_DIR/conf.d/welcome.conf $WEB_DIR/conf.d/welcome.conf.disabled
 
 # Add generated certificate to trust store
-RUN update-ca-trust force-enable \
-    && cp ${CERT_DIR}/combined.pem ${OS_CA_CERT_SOURCE_PATH}/ \
+# TODO: we used 'force-enable' on Rocky9 but unsupported on Rocky10 - does this work?
+#RUN update-ca-trust force-enable \
+RUN update-ca-trust \
+    && cp ${CERT_DIR}/server.crt ${OS_CA_CERT_SOURCE_PATH}/ \
     && update-ca-trust extract
 
 # rsyslog: Disable systemd and enable /dev/log
@@ -1564,15 +1528,12 @@ RUN if [ "${ENABLE_GDP}" = "True" ]; then \
       fi; \
     fi;
 
-# Install pylustrequota
+# Install lustreclient
 # NOTE: Requires py3 and git next branch
-RUN if [ "${ENABLE_QUOTA}" = "True" ] \
-            && [ "${PREFER_PYTHON3}" = "True" ] \
-            && [ "${WITH_GIT}" = "True" ] \
-            && [ "${MIG_GIT_BRANCH}" = "next" ]; then \
+RUN if [ "${ENABLE_QUOTA}" = "True" ]; then \
         if [ "${QUOTA_BACKEND}" = "lustre" ] \
             || [ "${QUOTA_BACKEND}" = "lustre-gocryptfs" ]; then \
-            echo "install pylustrequota" \
+            echo "install python lustreclient extensions" \
             && dnf update -y \
             && dnf --enablerepo=crb install -y \
             python3-devel.x86_64 \
@@ -1588,22 +1549,22 @@ RUN if [ "${ENABLE_QUOTA}" = "True" ] \
             krb5-devel.x86_64 \
             && dnf clean all \
             && rm -fr /var/cache/dnf \
-            && cd ${MIG_ROOT}/mig/src/pylustrequota \
+            && cd ${MIG_ROOT}/mig/src/lustreclient \
             && git clone https://github.com/lustre/lustre-release \
-            && cd ${MIG_ROOT}/mig/src/pylustrequota/lustre-release \
+            && cd ${MIG_ROOT}/mig/src/lustreclient/lustre-release \
             && git checkout ${QUOTA_LUSTRE_VERSION} \
             && sh ./autogen.sh \
             && ./configure --disable-server --enable-quota --enable-utils --enable-gss \
             && make undef.h \
-            && cd ${MIG_ROOT}/mig/src/pylustrequota/lustre-release/libcfs/libcfs \
+            && cd ${MIG_ROOT}/mig/src/lustreclient/lustre-release/libcfs/libcfs \
             && make libcfs.la \
-            && cd ${MIG_ROOT}/mig/src/pylustrequota/lustre-release/lnet/utils/lnetconfig \
+            && cd ${MIG_ROOT}/mig/src/lustreclient/lustre-release/lnet/utils/lnetconfig \
             && make liblnetconfig.la \
-            && cd ${MIG_ROOT}/mig/src/pylustrequota/lustre-release/lustre/utils \
+            && cd ${MIG_ROOT}/mig/src/lustreclient/lustre-release/lustre/utils \
             && make liblustreapi.la \
-            && cd ${MIG_ROOT}/mig/src/pylustrequota \
+            && cd ${MIG_ROOT}/mig/src/lustreclient \
             && python3 -m pip install --use-pep517 . \
-            && rm -rf ${MIG_ROOT}/mig/src/pylustrequota/lustre-release; \
+            && rm -rf ${MIG_ROOT}/mig/src/lustreclient/lustre-release; \
         fi; \
     fi;
 #------------------------- next stage -----------------------------#


### PR DESCRIPTION
Re-sync latest rocky9 changes into the #135 version and fix a few more or less obvious build errors. This is _not_ intended for merging, but just a test for potential integration into #135 if/when we are satisfied.

It was necessary to switch to the new official rockylinux repo at
https://hub.docker.com/r/rockylinux/rockylinux
for CI Actions to pull in rockylinux10 base images.

The build now succeeds but is not thoroughly verified yet and probably has rough edges, so please only use in pre-production testing for now.